### PR TITLE
0.5.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to (as crates are supposed to) [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- **Feed/Notifications/Threading refactor:**
+  - Feed now holds all posts, profiles, and a post-to-profile map using `Arc<Profile>` for safe shared ownership
+  - NotificationFeed and ThreadView now hold references to their base Feed and use it for all post/profile lookups and construction
+  - Added `Feed::profile_from_post` for mapping from a post reference to its profile
+  - Notification and threading logic now operate on posts from Feed, not raw vectors. They also hold refs to the feeds used in creation
+
+### Technical Details
+- Post now implements Eq, PartialEq and Hash - only the id is considered for those traits
+- Profile now implements Eq, PartialEq and Hash - only the title & nick are considered for those traits
+
 ## [0.4.3] - 10-09-2025
 ### Fixed
 - **Post summary**: Fixed the `Post::summary` function panicking when the split is in the middle of a multi-byte character (e.g. emoji)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to (as crates are supposed to) [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Update to spec 1.3
+
+### Added
+- **Group property**: Added support for the `:GROUP:` property in posts and profiles
+  - Profiles have a `Option<Vec<(String, String)>>` field representing group name and URL pairs
+  - Posts have a `Option<(String, String)>` field representing the group name and URL
+
 ### Changed
 - **Feed/Notifications/Threading refactor:**
   - Feed now holds all posts, profiles, and a post-to-profile map using `Arc<Profile>` for safe shared ownership

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to (as crates are supposed to) [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Update to spec 1.3
+
+### Changed
+- **Update to spec version 1.3** - Group support, see below
+- **Feed Architecture**: Complete redesign separating data storage from presentation views
+  - Feed now serves as pure data storage managing `Vec<Arc<Post>>` instead of owned posts
+  - Introduced `FeedView` trait for different feed presentation strategies
+  - Added `SimpleFeed` as the `FeedView` implementation for chronological display - the legacy "Feed"
+  - Feed manages multiple views via `Arc<Mutex<dyn FeedView>>`, for safe updates and sharing.
+- **Post Ownership**: All post handling converted to `Arc<Post>` for shared ownership without cloning
+  - All method signatures updated to use `Arc<Post>`
 
 ### Added
 - **Group property**: Added support for the `:GROUP:` property in posts and profiles
   - Profiles have a `Option<Vec<(String, String)>>` field representing group name and URL pairs
   - Posts have a `Option<(String, String)>` field representing the group name and URL
-
-### Changed
-- **Feed/Notifications/Threading refactor:**
-  - Feed now holds all posts, profiles, and a post-to-profile map using `Arc<Profile>` for safe shared ownership
-  - NotificationFeed and ThreadView now hold references to their base Feed and use it for all post/profile lookups and construction
-  - Added `Feed::profile_from_post` for mapping from a post reference to its profile
-  - Notification and threading logic now operate on posts from Feed, not raw vectors. They also hold refs to the feeds used in creation
+- **FeedView trait**: New trait defining view interface with methods:
+  - `update_content()` - Update view with new data
+  - `len()` - Get number of posts in view
+  - `is_empty()` - Check if view is empty
+  - `view_name()` - Get display name
+  - `refresh()` - Recompute derived data - currently fairly useless, since posts are immutable
 
 ### Technical Details
+- Memory efficiency improved by eliminating post data cloning across views and modules
+- Thread safety enhanced through consistent use of `Arc<T>` for shared ownership
+- Clear separation between data storage (Feed) and presentation (FeedView implementations)
 - Post now implements Eq, PartialEq and Hash - only the id is considered for those traits
 - Profile now implements Eq, PartialEq and Hash - only the title & nick are considered for those traits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to (as crates are supposed to) [Semantic Versioning](ht
 ### Changed
 - **Update to spec version 1.3** - Group support, see below
 - **Feed Architecture**: Complete redesign separating data storage from presentation views
-  - Feed now serves as pure data storage managing `Vec<Arc<Post>>` instead of owned posts
+  - Optimized for single-threaded use cases
+  - Feed now serves as pure data storage managing `Vec<Rc<RefCell<Post>>>` instead of owned posts
   - Introduced `FeedView` trait for different feed presentation strategies
   - Added `SimpleFeed` as the `FeedView` implementation for chronological display - the legacy "Feed"
-  - Feed manages multiple views via `Arc<Mutex<dyn FeedView>>`, for safe updates and sharing.
-- **Post Ownership**: All post handling converted to `Arc<Post>` for shared ownership without cloning
-  - All method signatures updated to use `Arc<Post>`
+  - Feed manages multiple views via `Rc<RefCell<dyn FeedView>>`, and updates them on data changes
+- **Post Ownership & Mutability**: All post handling converted to `Rc<RefCell<Post>>` for shared ownership with interior mutability
+  - Replaced `Post` with `Rc<RefCell<Post>>` to enable safe post mutation in single-threaded contexts
+  - All relevant method signatures updated to use `Rc<RefCell<Post>>`
 
 ### Added
 - **Group property**: Added support for the `:GROUP:` property in posts and profiles
@@ -28,7 +30,7 @@ and this project adheres to (as crates are supposed to) [Semantic Versioning](ht
 
 ### Technical Details
 - Memory efficiency improved by eliminating post data cloning across views and modules
-- Thread safety enhanced through consistent use of `Arc<T>` for shared ownership
+- Interior mutability enabled through `RefCell` for safe post mutation without thread-safety overhead
 - Clear separation between data storage (Feed) and presentation (FeedView implementations)
 - Post now implements Eq, PartialEq and Hash - only the id is considered for those traits
 - Profile now implements Eq, PartialEq and Hash - only the title & nick are considered for those traits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to (as crates are supposed to) [Semantic Versioning](ht
 - **Post Ownership & Mutability**: All post handling converted to `Rc<RefCell<Post>>` for shared ownership with interior mutability
   - Replaced `Post` with `Rc<RefCell<Post>>` to enable safe post mutation in single-threaded contexts
   - All relevant method signatures updated to use `Rc<RefCell<Post>>`
+- **Tokenizer Improvements**: Enhanced tokenizer to merge consecutive plain text tokens
+  - Previously, failure to close other tokens resulted in multiple consecutive plain text tokens
+  - Now, consecutive plain text tokens are merged into a single token for cleaner output
+  - Only tokens that are not separated by a newline are merged
+  - Should not affect existing behavior, as the tokens are equivalent
 
 ### Added
 - **Profile saving**: Added `Profile::save_to_file` method to save profile data back to org-social file
@@ -46,6 +51,7 @@ and this project adheres to (as crates are supposed to) [Semantic Versioning](ht
 - Clear separation between data storage (Feed) and presentation (FeedView implementations)
 - Post now implements Eq, PartialEq and Hash - only the id is considered for those traits
 - Profile now implements Eq, PartialEq and Hash - only the title & nick are considered for those traits
+- Tokenization now includes an extra pass to merge consecutive plain text tokens
 
 ## [0.4.3] - 10-09-2025
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to (as crates are supposed to) [Semantic Versioning](ht
   - All relevant method signatures updated to use `Rc<RefCell<Post>>`
 
 ### Added
+- **Profile saving**: Added `Profile::save_to_file` method to save profile data back to org-social file
+  - Preserves existing file structure and content outside of known profile properties
+  - Overrides present profile properties with new values
+  - Creates a new file if it does not exist
+  - If there are no post section, the `* Posts` header is added
 - **Feed filtering**: Added filtering capabilities to the Feed
   - There are lang, tag, author, source and group premade filters
   - Filters cannot be combined this way - all filters are stripped before applying a new one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to (as crates are supposed to) [Semantic Versioning](ht
   - `is_empty()` - Check if view is empty
   - `view_name()` - Get display name
   - `refresh()` - Recompute derived data - currently fairly useless, since posts are immutable
+  - `apply_filter()` - Apply a filter function to the posts in this view
 
 ### Technical Details
 - Memory efficiency improved by eliminating post data cloning across views and modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to (as crates are supposed to) [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 22-09-2025
 
 ### Changed
 - **Update to spec version 1.3** - Group support, see below

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to (as crates are supposed to) [Semantic Versioning](ht
   - All relevant method signatures updated to use `Rc<RefCell<Post>>`
 
 ### Added
+- **Feed filtering**: Added filtering capabilities to the Feed
+  - There are lang, tag, author, source and group premade filters
+  - Filters cannot be combined this way - all filters are stripped before applying a new one
+  - A custom filter function can be applied as well
+  - Filters are applied to all views, keeping the feed data intact
+  - Views can be refreshed to show all posts again
+  - Views themselves can also be filtered individually
 - **Group property**: Added support for the `:GROUP:` property in posts and profiles
   - Profiles have a `Option<Vec<(String, String)>>` field representing group name and URL pairs
   - Posts have a `Option<(String, String)>` field representing the group name and URL

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "org-social-lib-rs"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "org-social-lib-rs"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 authors = ["AdsanTheGreat <me@adsan.dev>"]
 description = "A Rust library for parsing and interacting with Org-social decentralized social networks"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ It basically constitutes the backend of any org-social application.
 
 ## Features
 
-- **Org-social Parsing**: Parse org-social files into profiles and posts
+- **Org-social Parsing**: Parse org-social files into profiles and posts, and safely write them back in that format
 - **Network Fetching**: Asynchronous fetching of remote org-social feeds
 - **Threading System**: Build threaded conversation view from reply relationships
-- **Feed Aggregation**: Combine multiple feeds into a unified, chronologically sorted feed
+- **Feed Aggregation**: Combine multiple feeds into a unified collection of posts to be viewed in different ways
 - **Post Management**: Create, parse, and manage social posts with metadata
 - **Notifications support**: Get the most important notifications for a user
 - **Poll support**: Manage posts with polls
@@ -31,7 +31,11 @@ In no particular order:
   - Tables
   - Latex - maybe
   - Lists
-- Network exploration - view not followed users
+- Relay client implementation
+  - Registering feeds
+  - Exploring existing feeds
+  - Joining groups, managing posts in groups
+  - Poll & reply tracking - integration with current threadview system
 - Documentation
 
 ## Installation
@@ -40,7 +44,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-org-social-lib-rs = "0.4.0"
+org-social-lib-rs = "0.5.0"
 ```
 
 Or if you want to use the latest development version from git:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Rust library for parsing and interacting with [Org-social](https://github.com/tanrax/org-social) decentralized social networks.
 
-Current version is targeting 1.2 release.
+Current version is targeting 1.3 release.
 
 ## Overview
 

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -76,8 +76,14 @@ impl Feed {
         }
     }
 
+    pub fn update_view(&self, view: &Rc<RefCell<dyn FeedView>>) {
+        let mut v = view.borrow_mut();
+        v.update_content(&self);
+        v.refresh();
+    }
+
     /// Update all views with current data.
-    fn update_all_views(&mut self) {
+    pub fn update_all_views(&self) {
         for view in &self.views {
             let mut v = view.borrow_mut();
             v.update_content(&self);
@@ -115,6 +121,101 @@ impl Feed {
             profiles: Vec::new(),
             profile_map: HashMap::new(),
             views: Vec::new(),
+        }
+    }
+
+    /// Apply a language filter to all the views.
+    /// This keeps the feed itself unchanged.
+    /// The views can be updated to show all posts again.
+    /// Strips all filters before applying the new one.
+    pub fn filter_by_lang(&self, lang: &str) {
+        self.update_all_views();
+        for view in &self.views {
+            let lang = lang.to_string();
+            let closure = Box::new(move |post: &Post| post.lang().as_deref() == Some(&lang));
+            let mut v = view.borrow_mut();
+            v.apply_filter(closure);
+        }
+    }
+
+    /// Apply a tag filter to all the views. At least one tag must match.
+    /// This keeps the feed itself unchanged.
+    /// The views can be updated to show all posts again.
+    /// Strips all filters before applying the new one.
+    pub fn filter_by_tag(&self, tag: &str) {
+        self.update_all_views();
+        for view in &self.views {
+            let tag = tag.to_string();
+            let closure = Box::new(move |post: &Post| {
+                post.tags()
+                    .as_ref()
+                    .map(|tags| tags.iter().any(|t| t == &tag))
+                    .unwrap_or(false)
+            });
+            let mut v = view.borrow_mut();
+            v.apply_filter(closure);
+        }
+    }
+
+    /// Apply an author filter to all the views.
+    /// This keeps the feed itself unchanged.
+    /// The views can be updated to show all posts again.
+    /// Strips all filters before applying the new one.
+    pub fn filter_by_author(&self, author: &str) {
+        self.update_all_views();
+        for view in &self.views {
+            let author = author.to_string();
+            let closure = Box::new(move |post: &Post| post.author().as_deref() == Some(&author));
+            let mut v = view.borrow_mut();
+            v.apply_filter(closure);
+        }
+    }
+
+    /// Apply a source filter to all the views.
+    /// This keeps the feed itself unchanged.
+    /// The views can be updated to show all posts again.
+    /// Strips all filters before applying the new one.
+    pub fn filter_by_source(&self, source: &str) {
+        self.update_all_views();
+        for view in &self.views {
+            let source = source.to_string();
+            let closure = Box::new(move |post: &Post| {
+                post.source()
+                    .as_ref()
+                    .map(|s| s == &source)
+                    .unwrap_or(false)
+            });
+            let mut v = view.borrow_mut();
+            v.apply_filter(closure);
+        }
+    }
+
+    /// This keeps the feed itself unchanged.
+    /// The views can be updated to show all posts again.
+    /// Strips all filters before applying the new one.
+    pub fn filter_by_group(&self, group: &str) {
+        self.update_all_views();
+        for view in &self.views {
+            let group = group.to_string();
+            let closure = Box::new(move |post: &Post| {
+                post.group().as_ref().map(|(g, _)| g == &group).unwrap_or(false)
+            });
+            let mut v = view.borrow_mut();
+            v.apply_filter(closure);
+        }
+    }
+
+    /// Apply a custom filter closure to the posts in all views.
+    /// This keeps the feed itself unchanged.
+    /// The views can be updated to show all posts again.
+    pub fn filter_custom(&self, filter_fn: Box<dyn Fn(&Post) -> bool + Send + Sync + 'static>) {
+        use std::sync::Arc;
+        self.update_all_views();
+        let filter_fn = Arc::new(filter_fn);
+        for view in &self.views {
+            let filter_fn = Arc::clone(&filter_fn);
+            let mut v = view.borrow_mut();
+            v.apply_filter(Box::new(move |post| filter_fn(post)));
         }
     }
 
@@ -318,6 +419,15 @@ impl FeedView for SimpleFeed {
                 (None, None) => std::cmp::Ordering::Equal,
             }
         });
+    }
+
+    fn apply_filter(&mut self, filter_fn: Box<dyn Fn(&crate::post::Post) -> bool>) {
+        self.posts = self.posts
+            .iter()
+            .filter(|post| filter_fn(&post.borrow()))
+            .cloned()
+            .collect();
+        self.refresh();
     }
 }
 

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -221,7 +221,7 @@ impl Feed {
 
     /// Create a new Feed from user profile and posts, fetching followed feeds.
     pub async fn new_from_user(user_profile: &Profile, user_posts: Vec<Post>) -> Result<Self, Box<dyn std::error::Error>> {
-    let mut all_posts: Vec<Rc<RefCell<Post>>> = Vec::new();
+        let mut all_posts: Vec<Rc<RefCell<Post>>> = Vec::new();
         let mut profiles: Vec<Arc<Profile>> = Vec::new();
 
         // Add user profile to profiles
@@ -267,7 +267,7 @@ impl Feed {
 
     /// Create a Feed with user posts only (no network fetching).
     pub fn from_user_posts(user_profile: &Profile, user_posts: Vec<Post>) -> Self {
-    let mut posts: Vec<Rc<RefCell<Post>>> = Vec::new();
+        let mut posts: Vec<Rc<RefCell<Post>>> = Vec::new();
         let mut profiles: Vec<Arc<Profile>> = Vec::new();
         let user_profile_arc = Arc::new(user_profile.clone());
         profiles.push(user_profile_arc.clone());
@@ -289,6 +289,25 @@ impl Feed {
         }
 
         Feed { posts, profiles, profile_map, views: Vec::new() }
+    }
+
+    /// Create a Feed from posts and profiles.
+    /// Assumes that authors are set correctly in posts
+    pub fn from_posts_and_profiles(posts: Vec<Post>, profiles: Vec<Profile>) -> Self {
+        let rc_posts: Vec<Rc<RefCell<Post>>> = posts.into_iter().map(|p| Rc::new(RefCell::new(p))).collect();
+        let arc_profiles: Vec<Arc<Profile>> = profiles.into_iter().map(|p| Arc::new(p)).collect();
+
+        // Build post->profile map using Arc<Profile>
+        let mut profile_map: HashMap<String, Arc<Profile>> = HashMap::new();
+        for post in &rc_posts {
+            if let Some(author) = post.borrow().author() {
+                if let Some(profile_arc) = arc_profiles.iter().find(|p| p.nick() == author).cloned() {
+                    profile_map.insert(post.borrow().id().to_string(), profile_arc);
+                }
+            }
+        }
+
+        Feed { posts: rc_posts, profiles: arc_profiles, profile_map, views: Vec::new() }
     }
 }
 

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -7,10 +7,12 @@
 //! while delegating presentation and filtering to various `FeedView` implementations.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::profile::Profile;
 use crate::post::Post;
+use std::rc::Rc;
+use std::cell::RefCell;
 use crate::feed_view::FeedView;
 use crate::network;
 
@@ -20,19 +22,17 @@ use crate::network;
 /// and manages multiple views that can present the data in different ways.
 /// Views share immutable references to the underlying data without cloning.
 pub struct Feed {
-    pub posts: Vec<Arc<Post>>,
+    pub posts: Vec<Rc<RefCell<Post>>>,
     pub profiles: Vec<Arc<Profile>>,
     pub profile_map: HashMap<String, Arc<Profile>>, // Maps post ID to profile
-    pub views: Vec<Arc<Mutex<dyn FeedView>>>,
+    pub views: Vec<Rc<RefCell<dyn FeedView>>>,
 }
 
 impl Feed {
     /// Add a view to this feed.
-    pub fn add_view(&mut self, view: Arc<Mutex<dyn FeedView>>) {
+    pub fn add_view(&mut self, view: Rc<RefCell<dyn FeedView>>) {
         // Update the view with current data
-        if let Ok(mut v) = view.lock() {
-            v.update_content(&self);
-        }
+        view.borrow_mut().update_content(&self);
         self.views.push(view);
     }
 
@@ -40,28 +40,24 @@ impl Feed {
     pub fn remove_view(&mut self, view_name: &str) -> bool {
         let initial_len = self.views.len();
         self.views.retain(|view| {
-            if let Ok(v) = view.lock() {
-                v.view_name() != view_name
-            } else {
-                true // Keep views that can't be locked
-            }
+            view.borrow().view_name() != view_name
         });
         self.views.len() != initial_len
     }
 
     /// Add posts to the feed and update all views.
     pub fn add_posts(&mut self, new_posts: Vec<Post>) {
-        let arc_posts: Vec<Arc<Post>> = new_posts.into_iter().map(Arc::new).collect();
-        self.posts.extend(arc_posts);
+    let rc_posts: Vec<Rc<RefCell<Post>>> = new_posts.into_iter().map(|p| Rc::new(RefCell::new(p))).collect();
+    self.posts.extend(rc_posts);
         self.update_all_views();
     }
 
     /// Add a single post to the feed and update all views.
-    pub fn add_post(&mut self, post: Post) -> Arc<Post> {
-        let arc_post = Arc::new(post);
-        self.posts.push(arc_post.clone());
+    pub fn add_post(&mut self, post: Post) -> Rc<RefCell<Post>> {
+        let rc_post = Rc::new(RefCell::new(post));
+        self.posts.push(rc_post.clone());
         self.update_all_views();
-        arc_post
+        rc_post
     }
 
     /// Add a profile to the feed.
@@ -83,23 +79,22 @@ impl Feed {
     /// Update all views with current data.
     fn update_all_views(&mut self) {
         for view in &self.views {
-            if let Ok(mut v) = view.lock() {
-                v.update_content(&self);
-                v.refresh();
-            }
+            let mut v = view.borrow_mut();
+            v.update_content(&self);
+            v.refresh();
         }
     }
 
     /// Get the profile for a specific post.
-    pub fn profile_for_post(&self, post: &Arc<Post>) -> Option<&Arc<Profile>> {
-        self.profile_map.get(post.id())
+    pub fn profile_for_post(&self, post: &Rc<RefCell<Post>>) -> Option<&Arc<Profile>> {
+        self.profile_map.get(post.borrow().id())
     }
 
     /// Get all posts from a single profile.
-    pub fn posts_from_profile(&self, profile: &Profile) -> Vec<&Arc<Post>> {
+    pub fn posts_from_profile(&self, profile: &Profile) -> Vec<Rc<RefCell<Post>>> {
         self.posts.iter().filter(|post| {
-            self.profile_map.get(post.id()).map(|p| p.as_ref() == profile).unwrap_or(false)
-        }).collect()
+            self.profile_map.get(post.borrow().id()).map(|p| p.as_ref() == profile).unwrap_or(false)
+        }).cloned().collect()
     }
 
     /// Get the number of posts.
@@ -114,9 +109,9 @@ impl Feed {
 
     /// Create a feed from posts for testing purposes.
     pub fn from_posts(posts: Vec<Post>) -> Self {
-        let arc_posts: Vec<Arc<Post>> = posts.into_iter().map(Arc::new).collect();
+        let rc_posts: Vec<Rc<RefCell<Post>>> = posts.into_iter().map(|p| Rc::new(RefCell::new(p))).collect();
         Feed {
-            posts: arc_posts,
+            posts: rc_posts,
             profiles: Vec::new(),
             profile_map: HashMap::new(),
             views: Vec::new(),
@@ -125,7 +120,7 @@ impl Feed {
 
     /// Create a new Feed from user profile and posts, fetching followed feeds.
     pub async fn new_from_user(user_profile: &Profile, user_posts: Vec<Post>) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut all_posts = Vec::new();
+    let mut all_posts: Vec<Rc<RefCell<Post>>> = Vec::new();
         let mut profiles: Vec<Arc<Profile>> = Vec::new();
 
         // Add user profile to profiles
@@ -141,7 +136,7 @@ impl Feed {
         // Build post list
         for mut post in user_posts {
             post.set_author(user_profile.nick().to_string());
-            all_posts.push(Arc::new(post));
+            all_posts.push(Rc::new(RefCell::new(post)));
         }
         for (profile, posts, source) in followed_feeds {
             let author_nick = if profile.nick().is_empty() {
@@ -152,7 +147,7 @@ impl Feed {
             for mut post in posts {
                 post.set_author(author_nick.clone());
                 post.set_source(Some(source.clone()));
-                all_posts.push(Arc::new(post));
+                all_posts.push(Rc::new(RefCell::new(post)));
             }
         }
 
@@ -160,10 +155,10 @@ impl Feed {
         let mut profile_map: HashMap<String, Arc<Profile>> = HashMap::new();
         for post in &all_posts {
             let profile_arc = profiles.iter()
-                .find(|p| post.author().as_deref() == Some(p.nick()))
+                .find(|p| post.borrow().author().as_deref() == Some(p.nick()))
                 .cloned()
                 .unwrap_or(user_profile_arc.clone());
-            profile_map.insert(post.id().to_string(), profile_arc);
+            profile_map.insert(post.borrow().id().to_string(), profile_arc);
         }
 
         Ok(Feed { posts: all_posts, profiles, profile_map, views: Vec::new() })
@@ -171,7 +166,7 @@ impl Feed {
 
     /// Create a Feed with user posts only (no network fetching).
     pub fn from_user_posts(user_profile: &Profile, user_posts: Vec<Post>) -> Self {
-        let mut posts = Vec::new();
+    let mut posts: Vec<Rc<RefCell<Post>>> = Vec::new();
         let mut profiles: Vec<Arc<Profile>> = Vec::new();
         let user_profile_arc = Arc::new(user_profile.clone());
         profiles.push(user_profile_arc.clone());
@@ -179,21 +174,21 @@ impl Feed {
         // Set author for user's own posts
         for mut post in user_posts {
             post.set_author(user_profile.nick().to_string());
-            posts.push(Arc::new(post));
+            posts.push(Rc::new(RefCell::new(post)));
         }
 
         // Build post->profile map using Arc<Profile>
         let mut profile_map: HashMap<String, Arc<Profile>> = HashMap::new();
         for post in &posts {
             let profile_arc = profiles.iter()
-                .find(|p| post.author().as_deref() == Some(p.nick()))
+                .find(|p| post.borrow().author().as_deref() == Some(p.nick()))
                 .cloned()
                 .unwrap_or(user_profile_arc.clone());
-            profile_map.insert(post.id().to_string(), profile_arc);
+            profile_map.insert(post.borrow().id().to_string(), profile_arc);
         }
 
         Feed { posts, profiles, profile_map, views: Vec::new() }
-    }    
+    }
 }
 
 /// A simple chronologically sorted feed view.
@@ -201,7 +196,7 @@ impl Feed {
 /// This is the basic feed implementation that presents posts in chronological order.
 /// It operates on the underlying Feed data without duplicating storage.
 pub struct SimpleFeed {
-    posts: Vec<Arc<Post>>,
+    posts: Vec<Rc<RefCell<Post>>>,
 }
 
 impl SimpleFeed {
@@ -218,7 +213,7 @@ impl SimpleFeed {
 
         // Sort posts chronologically (newest first)
         sorted_posts.sort_by(|a, b| {
-            match (a.time(), b.time()) {
+            match (a.borrow().time(), b.borrow().time()) {
                 (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
@@ -247,42 +242,42 @@ impl SimpleFeed {
         &self,
         start: chrono::DateTime<chrono::FixedOffset>,
         end: chrono::DateTime<chrono::FixedOffset>,
-    ) -> Vec<&Arc<Post>> {
+    ) -> Vec<Rc<RefCell<Post>>> {
         self.posts
             .iter()
             .filter(|post| {
-                if let Some(post_time) = post.time() {
+                if let Some(post_time) = post.borrow().time() {
                     post_time >= start && post_time <= end
                 } else {
                     false
                 }
             })
+            .cloned()
             .collect()
     }
 
-    pub fn get_recent_posts(&self, limit: usize) -> Vec<&Arc<Post>> {
-        self.posts.iter().take(limit).collect()
+    pub fn get_recent_posts(&self, limit: usize) -> Vec<Rc<RefCell<Post>>> {
+        self.posts.iter().take(limit).cloned().collect()
     }
 
-    pub fn posts_from_source(&self, source: &str) -> Vec<&Arc<Post>> {
+    pub fn posts_from_source(&self, source: &str) -> Vec<Rc<RefCell<Post>>> {
         self.posts
             .iter()
             .filter(|post| {
-                post.source()
+                post.borrow().source()
                     .as_ref()
                     .map(|s| s == source)
                     .unwrap_or(false)
             })
+            .cloned()
             .collect()
     }
 
     pub fn sources(&self) -> Vec<String> {
         let mut sources: Vec<String> = self.posts
             .iter()
-            .filter_map(|post| post.source().as_ref())
-            .cloned()
+            .filter_map(|post| post.borrow().source().as_ref().cloned())
             .collect();
-        
         sources.sort();
         sources.dedup();
         sources
@@ -316,7 +311,7 @@ impl FeedView for SimpleFeed {
     fn refresh(&mut self) {
         // Sort posts chronologically (newest first)
         self.posts.sort_by(|a, b| {
-            match (a.time(), b.time()) {
+            match (a.borrow().time(), b.borrow().time()) {
                 (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
@@ -330,14 +325,15 @@ impl std::fmt::Display for SimpleFeed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "SimpleFeed with {} posts:", self.posts.len())?;
         for (i, post) in self.posts.iter().enumerate() {
+            let post_ref = post.borrow();
             writeln!(f, "--- Post {} ---", i + 1)?;
-            if let Some(time) = post.time() {
+            if let Some(time) = post_ref.time() {
                 writeln!(f, "Time: {time}")?;
             }
-            if let Some(source) = post.source() {
+            if let Some(source) = post_ref.source() {
                 writeln!(f, "Source: {source}")?;
             }
-            writeln!(f, "{post}")?;
+            writeln!(f, "{post_ref}")?;
             writeln!(f)?;
         }
         Ok(())

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -2,27 +2,129 @@
 //!
 //! This module provides functionality to create, filter, and display
 //! feeds of org-social posts from multiple sources.
-//! The feed represantation is by default sorted chronologically with newest posts first.
+//! 
+//! The main `Feed` struct serves as a storage and management layer for posts and profiles,
+//! while delegating presentation and filtering to various `FeedView` implementations.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::profile::Profile;
 use crate::post::Post;
+use crate::feed_view::FeedView;
 use crate::network;
-use chrono::{DateTime, FixedOffset};
 
-/// Represents a collection of org-social posts from various sources.
+/// Main feed storage that manages posts, profiles, and multiple views.
 ///
-/// A feed contains posts, associated profiles, and a mapping from post ids to their author's profiles.
+/// The Feed struct serves as the central storage for posts and profiles,
+/// and manages multiple views that can present the data in different ways.
+/// Views share immutable references to the underlying data without cloning.
 pub struct Feed {
-    pub posts: Vec<Post>,
+    pub posts: Vec<Arc<Post>>,
     pub profiles: Vec<Arc<Profile>>,
     pub profile_map: HashMap<String, Arc<Profile>>, // Maps post ID to profile
+    pub views: Vec<Arc<Mutex<dyn FeedView>>>,
 }
 
 impl Feed {
-    pub async fn new(user_profile: &Profile, user_posts: Vec<Post>) -> Result<Feed, Box<dyn std::error::Error>>{
+    /// Add a view to this feed.
+    pub fn add_view(&mut self, view: Arc<Mutex<dyn FeedView>>) {
+        // Update the view with current data
+        if let Ok(mut v) = view.lock() {
+            v.update_content(&self);
+        }
+        self.views.push(view);
+    }
+
+    /// Remove a view from this feed.
+    pub fn remove_view(&mut self, view_name: &str) -> bool {
+        let initial_len = self.views.len();
+        self.views.retain(|view| {
+            if let Ok(v) = view.lock() {
+                v.view_name() != view_name
+            } else {
+                true // Keep views that can't be locked
+            }
+        });
+        self.views.len() != initial_len
+    }
+
+    /// Add posts to the feed and update all views.
+    pub fn add_posts(&mut self, new_posts: Vec<Post>) {
+        let arc_posts: Vec<Arc<Post>> = new_posts.into_iter().map(Arc::new).collect();
+        self.posts.extend(arc_posts);
+        self.update_all_views();
+    }
+
+    /// Add a single post to the feed and update all views.
+    pub fn add_post(&mut self, post: Post) -> Arc<Post> {
+        let arc_post = Arc::new(post);
+        self.posts.push(arc_post.clone());
+        self.update_all_views();
+        arc_post
+    }
+
+    /// Add a profile to the feed.
+    pub fn add_profile(&mut self, profile: Profile) -> Arc<Profile> {
+        let profile_arc = Arc::new(profile);
+        self.profiles.push(profile_arc.clone());
+        profile_arc
+    }
+
+    /// Set the author for posts and update the profile map.
+    pub fn set_posts_author(&mut self, posts_ids: &[String], author_nick: &str) {
+        if let Some(profile_arc) = self.profiles.iter().find(|p| p.nick() == author_nick).cloned() {
+            for post_id in posts_ids {
+                self.profile_map.insert(post_id.clone(), profile_arc.clone());
+            }
+        }
+    }
+
+    /// Update all views with current data.
+    fn update_all_views(&mut self) {
+        for view in &self.views {
+            if let Ok(mut v) = view.lock() {
+                v.update_content(&self);
+                v.refresh();
+            }
+        }
+    }
+
+    /// Get the profile for a specific post.
+    pub fn profile_for_post(&self, post: &Arc<Post>) -> Option<&Arc<Profile>> {
+        self.profile_map.get(post.id())
+    }
+
+    /// Get all posts from a single profile.
+    pub fn posts_from_profile(&self, profile: &Profile) -> Vec<&Arc<Post>> {
+        self.posts.iter().filter(|post| {
+            self.profile_map.get(post.id()).map(|p| p.as_ref() == profile).unwrap_or(false)
+        }).collect()
+    }
+
+    /// Get the number of posts.
+    pub fn len(&self) -> usize {
+        self.posts.len()
+    }
+
+    /// Check if the feed is empty.
+    pub fn is_empty(&self) -> bool {
+        self.posts.is_empty()
+    }
+
+    /// Create a feed from posts for testing purposes.
+    pub fn from_posts(posts: Vec<Post>) -> Self {
+        let arc_posts: Vec<Arc<Post>> = posts.into_iter().map(Arc::new).collect();
+        Feed {
+            posts: arc_posts,
+            profiles: Vec::new(),
+            profile_map: HashMap::new(),
+            views: Vec::new(),
+        }
+    }
+
+    /// Create a new Feed from user profile and posts, fetching followed feeds.
+    pub async fn new_from_user(user_profile: &Profile, user_posts: Vec<Post>) -> Result<Self, Box<dyn std::error::Error>> {
         let mut all_posts = Vec::new();
         let mut profiles: Vec<Arc<Profile>> = Vec::new();
 
@@ -39,7 +141,7 @@ impl Feed {
         // Build post list
         for mut post in user_posts {
             post.set_author(user_profile.nick().to_string());
-            all_posts.push(post);
+            all_posts.push(Arc::new(post));
         }
         for (profile, posts, source) in followed_feeds {
             let author_nick = if profile.nick().is_empty() {
@@ -50,7 +152,7 @@ impl Feed {
             for mut post in posts {
                 post.set_author(author_nick.clone());
                 post.set_source(Some(source.clone()));
-                all_posts.push(post);
+                all_posts.push(Arc::new(post));
             }
         }
 
@@ -64,30 +166,11 @@ impl Feed {
             profile_map.insert(post.id().to_string(), profile_arc);
         }
 
-        Ok(Feed { posts: all_posts, profiles, profile_map })
+        Ok(Feed { posts: all_posts, profiles, profile_map, views: Vec::new() })
     }
 
-    /// Creates a feed with the posts sorted chronologically, newest first.
-    pub async fn create_combined_feed(
-        user_profile: &Profile,
-        user_posts: Vec<Post>,
-    ) -> Result<Feed, Box<dyn std::error::Error>> {
-        let mut feed = Self::new(user_profile, user_posts).await?;
-
-        // Sort posts chronologically (newest first)
-        feed.posts.sort_by(|a, b| {
-            match (a.time(), b.time()) {
-                (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
-                (Some(_), None) => std::cmp::Ordering::Less,         // Posts with time come before posts without
-                (None, Some(_)) => std::cmp::Ordering::Greater,      // Posts without time come after posts with time
-                (None, None) => std::cmp::Ordering::Equal,           // Equal if both don't have time
-            }
-        });
-
-        Ok(feed)
-    }
-    
-    pub fn create_user_feed(user_profile: &Profile, user_posts: Vec<Post>) -> Feed {
+    /// Create a Feed with user posts only (no network fetching).
+    pub fn from_user_posts(user_profile: &Profile, user_posts: Vec<Post>) -> Self {
         let mut posts = Vec::new();
         let mut profiles: Vec<Arc<Profile>> = Vec::new();
         let user_profile_arc = Arc::new(user_profile.clone());
@@ -96,18 +179,8 @@ impl Feed {
         // Set author for user's own posts
         for mut post in user_posts {
             post.set_author(user_profile.nick().to_string());
-            posts.push(post);
+            posts.push(Arc::new(post));
         }
-
-        // Sort posts chronologically (newest first)
-        posts.sort_by(|a, b| {
-            match (a.time(), b.time()) {
-                (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => std::cmp::Ordering::Equal,
-            }
-        });
 
         // Build post->profile map using Arc<Profile>
         let mut profile_map: HashMap<String, Arc<Profile>> = HashMap::new();
@@ -119,8 +192,45 @@ impl Feed {
             profile_map.insert(post.id().to_string(), profile_arc);
         }
 
-        Feed { posts, profiles, profile_map }
+        Feed { posts, profiles, profile_map, views: Vec::new() }
+    }    
+}
+
+/// A simple chronologically sorted feed view.
+///
+/// This is the basic feed implementation that presents posts in chronological order.
+/// It operates on the underlying Feed data without duplicating storage.
+pub struct SimpleFeed {
+    posts: Vec<Arc<Post>>,
+}
+
+impl SimpleFeed {
+    /// Create a new empty SimpleFeed.
+    pub fn new() -> Self {
+        SimpleFeed {
+            posts: Vec::new(),
+        }
     }
+
+    /// Create a new SimpleFeed from existing data.
+    pub fn from_feed(feed: &Feed) -> Self {
+        let mut sorted_posts = feed.posts.to_vec();
+
+        // Sort posts chronologically (newest first)
+        sorted_posts.sort_by(|a, b| {
+            match (a.time(), b.time()) {
+                (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            }
+        });
+
+        SimpleFeed {
+            posts: sorted_posts,
+        }
+    }
+
     /// Filter posts by a specific time range.
     ///
     /// Returns posts that fall within the specified start and end times.
@@ -132,12 +242,12 @@ impl Feed {
     ///
     /// # Returns
     ///
-    /// A vector of references to posts within the time range.threading
+    /// A vector of references to posts within the time range.
     pub fn posts_in_range(
         &self,
-        start: DateTime<FixedOffset>,
-        end: DateTime<FixedOffset>,
-    ) -> Vec<&Post> {
+        start: chrono::DateTime<chrono::FixedOffset>,
+        end: chrono::DateTime<chrono::FixedOffset>,
+    ) -> Vec<&Arc<Post>> {
         self.posts
             .iter()
             .filter(|post| {
@@ -150,11 +260,11 @@ impl Feed {
             .collect()
     }
 
-    pub fn get_recent_posts(&self, limit: usize) -> Vec<&Post> {
+    pub fn get_recent_posts(&self, limit: usize) -> Vec<&Arc<Post>> {
         self.posts.iter().take(limit).collect()
     }
 
-    pub fn posts_from_source(&self, source: &str) -> Vec<&Post> {
+    pub fn posts_from_source(&self, source: &str) -> Vec<&Arc<Post>> {
         self.posts
             .iter()
             .filter(|post| {
@@ -186,15 +296,39 @@ impl Feed {
         self.posts.is_empty()
     }
 
-    pub fn profile_for_post(&self, post: &Post) -> Option<&Arc<Profile>> {
-        self.profile_map.get(post.id())
-    }
 
 }
 
-impl std::fmt::Display for Feed {
+impl FeedView for SimpleFeed {    
+    fn update_content(&mut self, feed: &Feed) {
+        self.posts = feed.posts.to_vec();
+        self.refresh();
+    }
+    
+    fn view_name(&self) -> &str {
+        "Chronological Feed"
+    }
+
+    fn len(&self) -> usize {
+        self.posts.len()
+    }
+    
+    fn refresh(&mut self) {
+        // Sort posts chronologically (newest first)
+        self.posts.sort_by(|a, b| {
+            match (a.time(), b.time()) {
+                (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            }
+        });
+    }
+}
+
+impl std::fmt::Display for SimpleFeed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Feed with {} posts:", self.posts.len())?;
+        writeln!(f, "SimpleFeed with {} posts:", self.posts.len())?;
         for (i, post) in self.posts.iter().enumerate() {
             writeln!(f, "--- Post {} ---", i + 1)?;
             if let Some(time) = post.time() {

--- a/src/feed_view.rs
+++ b/src/feed_view.rs
@@ -4,7 +4,7 @@
 //! over a shared collection of posts and profiles. Views can filter, sort, and present
 //! the data in different ways while sharing the underlying data.
 
-use crate::feed;
+use crate::{feed, post::Post};
 
 /// A trait for different views over feed data.
 ///
@@ -29,4 +29,7 @@ pub trait FeedView {
     
     /// Refresh the view - recompute any derived data
     fn refresh(&mut self);
+
+    /// Apply a filter function to the posts in this view
+    fn apply_filter(&mut self, filter_fn: Box<dyn Fn(&Post) -> bool>);
 }

--- a/src/feed_view.rs
+++ b/src/feed_view.rs
@@ -1,0 +1,32 @@
+//! Feed view trait and implementations for different feed display and filtering strategies.
+//!
+//! This module defines the `FeedView` trait that allows different views to be created
+//! over a shared collection of posts and profiles. Views can filter, sort, and present
+//! the data in different ways while sharing the underlying data.
+
+use crate::feed;
+
+/// A trait for different views over feed data.
+///
+/// Feed views provide different ways to present and interact with the same
+/// underlying collection of posts and profiles. Views share references to
+/// the posts without cloning the actual post data.
+pub trait FeedView: Send + Sync {  
+    /// Update the view with new posts and profiles.
+    /// This is called by the parent Feed when the underlying data changes, and when the view is first added.
+    fn update_content(&mut self, feed: &feed::Feed);
+    
+    /// Get the number of posts in this view.
+    fn len(&self) -> usize;
+    
+    /// Check if this view is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    
+    /// Get a display name for this view.
+    fn view_name(&self) -> &str;
+    
+    /// Refresh the view - recompute any derived data
+    fn refresh(&mut self);
+}

--- a/src/feed_view.rs
+++ b/src/feed_view.rs
@@ -11,7 +11,7 @@ use crate::feed;
 /// Feed views provide different ways to present and interact with the same
 /// underlying collection of posts and profiles. Views share references to
 /// the posts without cloning the actual post data.
-pub trait FeedView: Send + Sync {  
+pub trait FeedView {
     /// Update the view with new posts and profiles.
     /// This is called by the parent Feed when the underlying data changes, and when the view is first added.
     fn update_content(&mut self, feed: &feed::Feed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 
 pub mod blocks;
 pub mod feed;
+pub mod feed_view;
 pub mod network;
 pub mod new_post;
 pub mod notifications;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -7,10 +7,11 @@
 
 use crate::profile::Profile;
 use crate::post::Post;
-use crate::feed::Feed;
+use crate::feed::{self, Feed};
 use crate::tokenizer::Token;
 use chrono::{DateTime, FixedOffset};
 use std::collections::HashSet;
+use std::sync::Arc;
 
 /// Types of notifications that can occur
 #[derive(Debug, Clone, PartialEq)]
@@ -26,12 +27,12 @@ pub enum NotificationType {
 /// Represents a notification containing a post and the reason for notification
 #[derive(Debug, Clone)]
 pub struct Notification {
-    pub post: Post,
+    pub post: Arc<Post>,
     pub notification_type: NotificationType,
 }
 
 impl Notification {
-    pub fn new(post: Post, notification_type: NotificationType) -> Self {
+    pub fn new(post: Arc<Post>, notification_type: NotificationType) -> Self {
         Self {
             post,
             notification_type,
@@ -40,30 +41,25 @@ impl Notification {
 }
 
 /// Represents a collection of notifications for a user
-pub struct NotificationFeed<'a> {
-    pub feed: &'a Feed,
+pub struct NotificationFeed {
     pub notifications: Vec<Notification>,
+    target_profile: Profile,
 }
 
-impl<'a> NotificationFeed<'a> {
-    /// Create a notification feed for a user based on their profile and posts, using Feed as base
-    pub fn from_feed(feed: &'a Feed, user_profile: &Profile, user_posts: &[Post]) -> NotificationFeed<'a> {
+impl NotificationFeed {
+    /// Create a notification feed for a user based on their profile, using Feed as base
+    pub fn from_feed(feed: &Feed, user_profile: &Profile) -> NotificationFeed {
         let mut notifications = Vec::new();
-        let mut processed_post_ids = HashSet::new();
+        let user_posts = feed.posts_from_profile(&user_profile);
 
-        for post in &feed.posts {
+        for post in feed.posts.iter() {
             // Skip the user's own posts
             if post.author() == &Some(user_profile.nick().to_string()) {
                 continue;
             }
 
-            // Skip if we've already processed this post
-            if processed_post_ids.contains(post.id()) {
-                continue;
-            }
-
-            let is_mention = is_mention_to_user(post, user_profile);
-            let is_reply = is_reply_to_user(post, user_posts);
+            let is_mention = is_mention_to_user(&post, &user_profile);
+            let is_reply = is_reply_to_user(&post, &user_posts);
 
             let notification_type = match (is_mention, is_reply) {
                 (true, true) => Some(NotificationType::MentionAndReply),
@@ -74,7 +70,6 @@ impl<'a> NotificationFeed<'a> {
 
             if let Some(notification_type) = notification_type {
                 notifications.push(Notification::new(post.clone(), notification_type));
-                processed_post_ids.insert(post.id().to_string());
             }
         }
 
@@ -88,7 +83,7 @@ impl<'a> NotificationFeed<'a> {
             }
         });
 
-        NotificationFeed { feed, notifications }
+        NotificationFeed { notifications, target_profile: user_profile.clone() }
     }
 
     /// Filter notifications by a specific time range
@@ -212,7 +207,7 @@ fn is_mention_to_user(post: &Post, user_profile: &Profile) -> bool {
 /// # Returns
 ///
 /// `true` if the post is a reply to any of the user's posts, `false` otherwise
-fn is_reply_to_user(post: &Post, user_posts: &[Post]) -> bool {
+fn is_reply_to_user(post: &Post, user_posts: &Vec<&Arc<Post>>) -> bool {
     if let Some(reply_to) = post.reply_to() {
         // Extract the post ID from the reply_to URL
         let reply_id = if let Some(hash_pos) = reply_to.rfind('#') {
@@ -228,7 +223,7 @@ fn is_reply_to_user(post: &Post, user_posts: &[Post]) -> bool {
     false
 }
 
-impl<'a> std::fmt::Display for NotificationFeed<'a> {
+impl std::fmt::Display for NotificationFeed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Notification Feed with {} notifications:", self.notifications.len())?;
         
@@ -251,94 +246,3 @@ impl<'a> std::fmt::Display for NotificationFeed<'a> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::profile::Profile;
-    use crate::post::Post;
-
-    #[test]
-    fn test_mention_detection() {
-        let mut user_profile = Profile::default();
-        user_profile.set_nick("testuser".to_string());
-        user_profile.set_source(Some("https://example.com/social.org".to_string()));
-
-        // Create a post with a mention
-        let post_content = "Hello [[org-social:https://example.com/social.org][testuser]]!".to_string();
-        let mut post = Post::new("test123".to_string(), post_content);
-        post.parse_content(); // Ensure tokens are parsed
-
-        assert!(is_mention_to_user(&post, &user_profile));
-    }
-
-    #[test]
-    fn test_reply_detection() {
-        let user_posts = vec![
-            Post::new("user_post_1".to_string(), "First user post".to_string()),
-            Post::new("user_post_2".to_string(), "Second user post".to_string()),
-        ];
-
-        let mut reply_post = Post::new("reply_1".to_string(), "This is a reply".to_string());
-        reply_post.set_reply_to(Some("https://example.com/social.org#user_post_1".to_string()));
-
-        assert!(is_reply_to_user(&reply_post, &user_posts));
-    }
-
-    #[test]
-    fn test_notification_feed_creation() {
-        let mut user_profile = Profile::default();
-        user_profile.set_nick("testuser".to_string());
-
-        let user_posts = vec![
-            Post::new("user_post_1".to_string(), "User's post".to_string()),
-        ];
-
-        let mut mention_post = Post::new("mention_1".to_string(), 
-            "Hello [[org-social:https://example.com/social.org][testuser]]!".to_string());
-        mention_post.parse_content();
-
-        let mut reply_post = Post::new("reply_1".to_string(), "Reply to user".to_string());
-        reply_post.set_reply_to(Some("https://example.com/social.org#user_post_1".to_string()));
-
-        let mut all_posts = user_posts.clone();
-        all_posts.push(mention_post.clone());
-        all_posts.push(reply_post.clone());
-        let feed = crate::feed::Feed { posts: all_posts, profiles: vec![], profile_map: std::collections::HashMap::new() };
-        let notification_feed = NotificationFeed::from_feed(
-            &feed,
-            &user_profile,
-            &user_posts,
-        );
-
-        assert_eq!(notification_feed.len(), 2);
-    }
-
-    #[test]
-    fn test_no_duplicates_for_mention_and_reply() {
-        let mut user_profile = Profile::default();
-        user_profile.set_nick("testuser".to_string());
-
-        let user_posts = vec![
-            Post::new("user_post_1".to_string(), "User's post".to_string()),
-        ];
-
-        // Create a post that both mentions the user and replies to their post
-        let mut mention_and_reply_post = Post::new("both_1".to_string(), 
-            "Reply to [[org-social:https://example.com/social.org][testuser]]'s post".to_string());
-        mention_and_reply_post.set_reply_to(Some("https://example.com/social.org#user_post_1".to_string()));
-        mention_and_reply_post.parse_content();
-
-        let mut all_posts = user_posts.clone();
-        all_posts.push(mention_and_reply_post.clone());
-        let feed = crate::feed::Feed { posts: all_posts, profiles: vec![], profile_map: std::collections::HashMap::new() };
-        let notification_feed = NotificationFeed::from_feed(
-            &feed,
-            &user_profile,
-            &user_posts,
-        );
-
-        // Should have exactly one notification with type MentionAndReply
-        assert_eq!(notification_feed.len(), 1);
-        assert_eq!(notification_feed.notifications[0].notification_type, NotificationType::MentionAndReply);
-    }
-}

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -5,6 +5,7 @@
 //! Notifications are sorted chronologically with newest first. 
 //! Duplicates of the same post are dropped.
 
+use crate::feed_view::FeedView;
 use crate::profile::Profile;
 use crate::post::Post;
 use crate::feed::Feed;
@@ -153,6 +154,46 @@ impl NotificationFeed {
     /// Check if the notification feed is empty
     pub fn is_empty(&self) -> bool {
         self.notifications.is_empty()
+    }
+}
+
+impl FeedView for NotificationFeed {
+    fn update_content(&mut self, feed: &Feed) {
+        self.notifications = NotificationFeed::from_feed(feed, &self.target_profile).notifications;
+        
+    }
+
+    fn len(&self) -> usize {
+        self.notifications.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.notifications.is_empty()
+    }
+    fn view_name(&self) -> &str {
+        "Notification View"
+    }
+
+    fn refresh(&mut self) {
+        self.notifications.sort_by(|a, b| {
+            let a_time = a.post.borrow().time();
+            let b_time = b.post.borrow().time();
+            match (a_time, b_time) {
+                (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
+                (Some(_), None) => std::cmp::Ordering::Less,         // Posts with time come before posts without
+                (None, Some(_)) => std::cmp::Ordering::Greater,      // Posts without time come after posts with time
+                (None, None) => std::cmp::Ordering::Equal,           // Equal if both don't have time
+            }
+        });
+    }
+
+    fn apply_filter(&mut self, filter_fn: Box<dyn Fn(&Post) -> bool>) {
+        self.notifications = self.notifications
+            .iter()
+            .filter(|notification| filter_fn(&notification.post.borrow()))
+            .cloned()
+            .collect();
+        self.refresh();
     }
 }
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -7,11 +7,11 @@
 
 use crate::profile::Profile;
 use crate::post::Post;
-use crate::feed::{self, Feed};
+use crate::feed::Feed;
 use crate::tokenizer::Token;
 use chrono::{DateTime, FixedOffset};
-use std::collections::HashSet;
-use std::sync::Arc;
+use std::rc::Rc;
+use std::cell::RefCell;
 
 /// Types of notifications that can occur
 #[derive(Debug, Clone, PartialEq)]
@@ -27,12 +27,12 @@ pub enum NotificationType {
 /// Represents a notification containing a post and the reason for notification
 #[derive(Debug, Clone)]
 pub struct Notification {
-    pub post: Arc<Post>,
+    pub post: Rc<RefCell<Post>>,
     pub notification_type: NotificationType,
 }
 
 impl Notification {
-    pub fn new(post: Arc<Post>, notification_type: NotificationType) -> Self {
+    pub fn new(post: Rc<RefCell<Post>>, notification_type: NotificationType) -> Self {
         Self {
             post,
             notification_type,
@@ -53,13 +53,14 @@ impl NotificationFeed {
         let user_posts = feed.posts_from_profile(&user_profile);
 
         for post in feed.posts.iter() {
+            let post_ref = post.borrow();
             // Skip the user's own posts
-            if post.author() == &Some(user_profile.nick().to_string()) {
+            if post_ref.author() == &Some(user_profile.nick().to_string()) {
                 continue;
             }
 
-            let is_mention = is_mention_to_user(&post, &user_profile);
-            let is_reply = is_reply_to_user(&post, &user_posts);
+            let is_mention = is_mention_to_user(&post_ref, &user_profile);
+            let is_reply = is_reply_to_user(&post_ref, &user_posts);
 
             let notification_type = match (is_mention, is_reply) {
                 (true, true) => Some(NotificationType::MentionAndReply),
@@ -75,7 +76,9 @@ impl NotificationFeed {
 
         // Sort notifications chronologically (newest first)
         notifications.sort_by(|a, b| {
-            match (a.post.time(), b.post.time()) {
+            let a_time = a.post.borrow().time();
+            let b_time = b.post.borrow().time();
+            match (a_time, b_time) {
                 (Some(time_a), Some(time_b)) => time_b.cmp(&time_a), // Reverse order for newest first
                 (Some(_), None) => std::cmp::Ordering::Less,         // Posts with time come before posts without
                 (None, Some(_)) => std::cmp::Ordering::Greater,      // Posts without time come after posts with time
@@ -104,7 +107,7 @@ impl NotificationFeed {
         self.notifications
             .iter()
             .filter(|notification| {
-                if let Some(post_time) = notification.post.time() {
+                if let Some(post_time) = notification.post.borrow().time() {
                     post_time >= start && post_time <= end
                 } else {
                     false
@@ -207,7 +210,7 @@ fn is_mention_to_user(post: &Post, user_profile: &Profile) -> bool {
 /// # Returns
 ///
 /// `true` if the post is a reply to any of the user's posts, `false` otherwise
-fn is_reply_to_user(post: &Post, user_posts: &Vec<&Arc<Post>>) -> bool {
+fn is_reply_to_user(post: &Post, user_posts: &Vec<Rc<RefCell<Post>>>) -> bool {
     if let Some(reply_to) = post.reply_to() {
         // Extract the post ID from the reply_to URL
         let reply_id = if let Some(hash_pos) = reply_to.rfind('#') {
@@ -217,7 +220,7 @@ fn is_reply_to_user(post: &Post, user_posts: &Vec<&Arc<Post>>) -> bool {
         };
 
         // Check if any user post matches this reply ID
-        return user_posts.iter().any(|user_post| user_post.id() == reply_id);
+        return user_posts.iter().any(|user_post| user_post.borrow().id() == reply_id);
     }
 
     false
@@ -229,16 +232,17 @@ impl std::fmt::Display for NotificationFeed {
         
         for (i, notification) in self.notifications.iter().enumerate() {
             writeln!(f, "--- Notification {} ({:?}) ---", i + 1, notification.notification_type)?;
-            if let Some(time) = notification.post.time() {
+            let post_ref = notification.post.borrow();
+            if let Some(time) = post_ref.time() {
                 writeln!(f, "Time: {time}")?;
             }
-            if let Some(author) = notification.post.author() {
+            if let Some(author) = post_ref.author() {
                 writeln!(f, "Author: {author}")?;
             }
-            if let Some(source) = notification.post.source() {
+            if let Some(source) = post_ref.source() {
                 writeln!(f, "Source: {source}")?;
             }
-            writeln!(f, "{}", notification.post)?;
+            writeln!(f, "{}", post_ref)?;
             writeln!(f)?;
         }
         

--- a/src/post.rs
+++ b/src/post.rs
@@ -16,7 +16,7 @@ use crate::blocks::{ActivatableElement, parse_blocks_with_poll_end};
 
 /// Represents the type of a post based on its properties.
 /// Used for categorizing posts as regular posts, polls, replies, or votes.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub enum PostType {
     /// A non-reply post that is not a poll, a standalone standard post.
     Regular,
@@ -223,6 +223,21 @@ impl Display for Post {
             "Post:\nID: {}\nLang: {:?}\nTags: {:?}\nClient: {:?}\nReply To: {:?}\nPoll End: {:?}\nPoll Option: {:?}\nMood: {:?}\nSource: {:?}\nAuthor: {:?}\nTokens: {} parsed\nBlocks: {} parsed\nContent:\n{}",
             self.id, self.lang, self.tags, self.client, self.reply_to, self.poll_end, self.poll_option, self.mood, self.source, self.author, self.tokens.len(), self.blocks.len(), self.content
         )
+    }
+}
+
+impl std::cmp::PartialEq for Post {
+    /// Posts are considered equal when they have the same id
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl std::cmp::Eq for Post {}
+
+impl std::hash::Hash for Post {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 

--- a/src/post.rs
+++ b/src/post.rs
@@ -56,6 +56,7 @@ pub struct Post {
     mood: Option<String>,
     pub(crate) content: String,
     source: Option<String>,
+    group: Option<(String, String)>,
     author: Option<String>,
     tokens: Vec<Token>,
     blocks: Vec<ActivatableElement>,
@@ -75,6 +76,7 @@ impl From<&Post> for Post {
             mood: post.mood.clone(),
             content: post.content.clone(),
             source: post.source.clone(),
+            group: post.group.clone(),
             author: post.author.clone(),
             tokens: post.tokens.clone(),
             blocks: post.blocks.clone(),
@@ -96,6 +98,7 @@ impl From<Vec<String>> for Post {
         let mut poll_option: Option<String> = None;
         let mut mood: Option<String> = None;
         let mut content = String::new();
+        let mut group: Option<(String, String)> = None;
 
         let mut in_properties = false;
         let mut properties_ended = false;
@@ -138,6 +141,12 @@ impl From<Vec<String>> for Post {
                         ":POLL_END" => poll_end = Some(parts[1].trim().to_string()),
                         ":POLL_OPTION" => poll_option = Some(parts[1].trim().to_string()),
                         ":MOOD" => mood = Some(parts[1].trim().to_string()),
+                        ":GROUP" => {
+                            let group_parts: Vec<&str> = parts[1].splitn(2, ' ').collect();
+                            if group_parts.len() == 2 {
+                                group = Some((group_parts[0].to_string(), group_parts[1].to_string()));
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -205,6 +214,7 @@ impl From<Vec<String>> for Post {
             mood,
             content,
             source: None,
+            group,
             author: None,
             tokens: Vec::new(),
             blocks: Vec::new(),
@@ -220,8 +230,8 @@ impl Display for Post {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Post:\nID: {}\nLang: {:?}\nTags: {:?}\nClient: {:?}\nReply To: {:?}\nPoll End: {:?}\nPoll Option: {:?}\nMood: {:?}\nSource: {:?}\nAuthor: {:?}\nTokens: {} parsed\nBlocks: {} parsed\nContent:\n{}",
-            self.id, self.lang, self.tags, self.client, self.reply_to, self.poll_end, self.poll_option, self.mood, self.source, self.author, self.tokens.len(), self.blocks.len(), self.content
+            "Post:\nID: {}\nLang: {:?}\nTags: {:?}\nClient: {:?}\nReply To: {:?}\nPoll End: {:?}\nPoll Option: {:?}\nMood: {:?}\nSource: {:?}\nGroup: {:?}\nAuthor: {:?}\nTokens: {} parsed\nBlocks: {} parsed\nContent:\n{}",
+            self.id, self.lang, self.tags, self.client, self.reply_to, self.poll_end, self.poll_option, self.mood, self.source, self.group, self.author, self.tokens.len(), self.blocks.len(), self.content
         )
     }
 }
@@ -346,6 +356,10 @@ impl Post {
 
     pub fn author(&self) -> &Option<String> {
         &self.author
+    }
+
+    pub fn group(&self) -> &Option<(String, String)> {
+        &self.group
     }
 
     pub fn set_author(&mut self, author: String) {
@@ -480,6 +494,10 @@ impl Post {
             metadata.push(format!("Client: {}", client));
         }
 
+        if let Some(group) = self.group() {
+            metadata.push(format!("Group: {} - {}", group.0, group.1));
+        }
+
         if let Some(reply_to) = self.reply_to() {
             // Extract the post ID from the reply_to URL 
             let reply_id = if let Some(hash_pos) = reply_to.rfind('#') {
@@ -582,6 +600,10 @@ impl Post {
 
         if let Some(client) = &self.client {
             lines.push(format!(":CLIENT: {client}"));
+        }
+
+        if let Some(group) = &self.group {
+            lines.push(format!(":GROUP: {} {}", group.0, group.1));
         }
 
         if let Some(reply_to) = &self.reply_to {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -8,8 +8,7 @@ use std::collections::HashMap;
 /// Represents a user profile parsed from an org-social file.
 /// 
 /// Contains metadata about the user.
-#[derive(Clone)]
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Profile {
     title: String,
     nick: String,
@@ -174,6 +173,23 @@ impl std::fmt::Display for Profile {
     }
 }
 
+impl PartialEq for Profile {
+    /// Profiles are considered equal when they have the same title and nick
+    fn eq(&self, other: &Self) -> bool {
+        self.title == other.title &&
+        self.nick == other.nick
+    }
+}
+
+impl Eq for Profile {}
+
+impl core::hash::Hash for Profile {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.title.hash(state);
+        self.nick.hash(state);
+    }
+}
+
 impl Profile {
     pub fn follow(&self) -> &Option<Vec<(String, String)>> {
         &self.follow
@@ -253,6 +269,15 @@ impl Profile {
         }
 
         lines.join("\n")
+    }
+
+    pub fn add_follow(&mut self, nick: String, url: String) {
+        if self.follow.is_none() {
+            self.follow = Some(Vec::new());
+        }
+        if let Some(follow) = &mut self.follow {
+            follow.push((nick, url));
+        }
     }
 
     pub fn create_follow_map(&self) -> HashMap<String, String> {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -4,6 +4,9 @@
 //! for parsing and serializing user profile metadata.
 
 use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::Path;
 
 /// Represents a user profile parsed from an org-social file.
 /// 
@@ -348,5 +351,115 @@ impl Profile {
         }
 
         Some(result)
+    }
+
+    /// Save this profile to a file, preserving comments, unknown lines, and posts section.
+    /// 
+    /// This function reads the existing file, identifies the profile section (everything before "* Posts"),
+    /// replaces only the known profile lines while preserving comments and unknown syntax in their
+    /// original positions, and keeps the posts section intact.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `file_path` - Path to the org-social file to update
+    /// 
+    /// # Returns
+    /// 
+    /// Result indicating success or failure with error details
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if the file cannot be read or written, or if I/O operations fail.
+    pub fn save_to_file<P: AsRef<Path>>(&self, file_path: P) -> io::Result<()> {
+        let file_path = file_path.as_ref();
+        
+        // Read existing file content, or start with empty if file doesn't exist
+        let existing_content = if file_path.exists() {
+            fs::read_to_string(file_path)?
+        } else {
+            String::new()
+        };
+        let lines: Vec<String> = existing_content
+            .lines()
+            .map(String::from)
+            .collect();
+
+        // Split into profile section and posts section
+        let posts_index = lines
+            .iter()
+            .position(|line| line.starts_with("* Posts"))
+            .unwrap_or(lines.len());
+        let profile_section_lines = lines.split_at(posts_index).0;
+        let posts_section_lines = if posts_index < lines.len() {
+            lines.split_at(posts_index).1
+        } else {
+            &[]
+        };
+
+        let known_profile_prefixes = [
+            "#+TITLE:",
+            "#+NICK:",
+            "#+DESCRIPTION:",
+            "#+AVATAR:",
+            "#+LINK:",
+            "#+FOLLOW:",
+            "#+GROUP:",
+            "#+CONTACT:",
+        ];
+
+        // Create a set of indices for lines that should be skipped (known profile lines)
+        let mut skip_indices = std::collections::HashSet::new();
+        for (i, line) in profile_section_lines.iter().enumerate() {
+            let is_known_profile_line = known_profile_prefixes
+                .iter()
+                .any(|prefix| line.trim().starts_with(prefix));
+            
+            if is_known_profile_line {
+                skip_indices.insert(i);
+            }
+        }
+
+        let mut output = Vec::new();
+
+        // Add profile section lines, preserving positions but skipping known profile lines
+        for (i, line) in profile_section_lines.iter().enumerate() {
+            if !skip_indices.contains(&i) {
+                output.push(line.clone());
+            }
+        }
+
+        // Find a good position to insert the new profile content
+        // We'll add it after any preserved lines but before posts
+        let profile_content = self.to_org_social();
+        if !profile_content.is_empty() {
+            // Add an empty line before profile if there were preserved lines
+            if !output.is_empty() && !output.last().unwrap().trim().is_empty() {
+                output.push("".to_string());
+            }
+            output.push(profile_content.clone());
+        }
+
+        // Add posts section if it existed, or create one if it didn't
+        if !posts_section_lines.is_empty() {
+            // Add empty line before posts section if profile content was added
+            if !profile_content.is_empty() {
+                output.push("".to_string());
+            }
+            for line in posts_section_lines {
+                output.push(line.clone());
+            }
+        } else {
+            // No posts section existed, so create one in preparation for future posts
+            if !profile_content.is_empty() {
+                output.push("".to_string());
+            }
+            output.push("* Posts".to_string());
+        }
+
+        // Write the new content to the file
+        let final_content = output.join("\n");
+        fs::write(file_path, final_content)?;
+
+        Ok(())
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -16,6 +16,7 @@ pub struct Profile {
     avatar: Option<String>,
     link: Option<Vec<String>>,
     follow: Option<Vec<(String, String)>>,
+    groups: Option<Vec<(String, String)>>,
     contact: Option<Vec<String>>,
     source: Option<String>,
 }
@@ -30,6 +31,7 @@ impl From<&Profile> for Profile {
             avatar: profile.avatar.clone(),
             link: profile.link.clone(),
             follow: profile.follow.clone(),
+            groups: profile.groups.clone(),
             contact: profile.contact.clone(),
             source: profile.source.clone(),
         }
@@ -47,6 +49,7 @@ impl From<Vec<String>> for Profile {
         let mut avatar: Option<String> = None;
         let mut link: Option<Vec<String>> = None;
         let mut follow: Option<Vec<(String, String)>> = None;
+        let mut groups: Option<Vec<(String, String)>> = None;
         let mut contact: Option<Vec<String>> = None;
 
         for line in profile_section_lines {
@@ -83,6 +86,19 @@ impl From<Vec<String>> for Profile {
                             ));
                         }
                     }
+                    "#+GROUP" => {
+                        if groups.is_none() {
+                            groups = Some(Vec::new());
+                        }
+                        // Parse "name url" format or "url"
+                        let groups_parts: Vec<&str> = parts[1].trim().splitn(2, ' ').collect();
+                        if groups_parts.len() == 2 {
+                            groups.as_mut().unwrap().push((
+                                groups_parts[0].to_string(),
+                                groups_parts[1].to_string(),
+                            ));
+                        } // No unnamed groupss
+                    }
                     "#+CONTACT" => {
                         if contact.is_none() {
                             contact = Some(Vec::new());
@@ -101,6 +117,7 @@ impl From<Vec<String>> for Profile {
             avatar,
             link,
             follow,
+            groups,
             contact,
             source: None,
         }
@@ -152,6 +169,22 @@ impl std::fmt::Display for Profile {
             }
         }
         
+        if let Some(groups) = &self.groups {
+            if !groups.is_empty() {
+                output.push(format!("groups: {} {}", 
+                    groups.len(),
+                    if groups.len() == 1 { "group" } else { "groups" }
+                ));
+                for (i, (name, url)) in groups.iter().enumerate() {
+                    output.push(format!("  {}. {} - {}", 
+                        i + 1,
+                        name, 
+                        url
+                    ));
+                }
+            }
+        }
+        
         if let Some(contacts) = &self.contact {
             if !contacts.is_empty() {
                 if contacts.len() == 1 {
@@ -193,6 +226,10 @@ impl core::hash::Hash for Profile {
 impl Profile {
     pub fn follow(&self) -> &Option<Vec<(String, String)>> {
         &self.follow
+    }
+
+    pub fn groups(&self) -> &Option<Vec<(String, String)>> {
+        &self.groups
     }
 
     pub fn title(&self) -> &str {
@@ -259,6 +296,12 @@ impl Profile {
         if let Some(follows) = &self.follow {
             for (nick, url) in follows {
                 lines.push(format!("#+FOLLOW: {nick} {url}"));
+            }
+        }
+
+        if let Some(groups) = &self.groups {
+            for (name, url) in groups {
+                lines.push(format!("#+GROUP: {name} {url}"));
             }
         }
 

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -3,17 +3,17 @@
 //! This module provides functionality to organize posts into threaded conversations
 //! based on reply relationships, creating hierarchical tree structures for display.
 
-use crate::feed;
-use crate::{feed::Feed, feed_view::FeedView, poll::Poll, post::Post, profile::Profile};
+use crate::{feed::Feed, feed_view::FeedView, poll::Poll, post::Post};
 use chrono::{DateTime, FixedOffset};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::rc::Rc;
+use std::cell::RefCell;
 
 /// Represents a node in a threaded conversation tree.
 #[derive(Clone)]
 pub struct ThreadNode {
     /// The post at this node
-    pub post: Arc<Post>,
+    pub post: Rc<RefCell<Post>>,
     /// Direct replies to this post
     pub replies: Vec<ThreadNode>,
     /// Depth level in the conversation (0 = root)
@@ -33,8 +33,8 @@ pub struct ThreadView {
 }
 
 impl ThreadNode {
-    pub fn new(post: Arc<Post>, depth: usize) -> Self {
-        let latest_activity_time = post.time();
+    pub fn new(post: Rc<RefCell<Post>>, depth: usize) -> Self {
+        let latest_activity_time = post.borrow().time();
         Self {
             post,
             replies: Vec::new(),
@@ -56,7 +56,7 @@ impl ThreadNode {
         }
         
         // Start with this post's own time
-        let mut latest_time = self.post.time();
+        let mut latest_time = self.post.borrow().time();
         
         // Check all replies for later times
         for reply in &self.replies {
@@ -96,7 +96,7 @@ impl ThreadNode {
         1 + self.replies.iter().map(|r| r.count_posts()).sum::<usize>()
     }
 
-    pub fn flatten(&self) -> Vec<&Arc<Post>> {
+    pub fn flatten(&self) -> Vec<&Rc<RefCell<Post>>> {
         let mut posts = vec![&self.post];
         for reply in &self.replies {
             posts.extend(reply.flatten());
@@ -118,23 +118,26 @@ impl ThreadView {
 
         // Build ID mapping for quick lookups
         for post in feed.posts.iter() {
-            let full_id: String = post.full_id();
-            thread_view.id_map.insert(post.id().to_string(), full_id);
+            let post_ref = post.borrow();
+            let full_id: String = post_ref.full_id();
+            thread_view.id_map.insert(post_ref.id().to_string(), full_id);
         }
 
         // First pass: create nodes for all posts
         for post in feed.posts.iter() {
+            let post_ref = post.borrow();
             let node = ThreadNode::new(post.clone(), 0);
-            let full_id = post.full_id();
+            let full_id = post_ref.full_id();
             post_map.insert(full_id, node);
         }
 
         // Second pass: organize into threads and create placeholders for missing parents
         let post_map_clone = post_map.clone();
         for (_post_id, mut node) in post_map {
-            if let Some(reply_to) = node.post.reply_to() {
+            let reply_to = node.post.borrow().reply_to().clone();
+            if let Some(reply_to) = reply_to {
                 // This is a reply to another post
-                let reply_target = Self::resolve_reply_target(reply_to, &thread_view.id_map);
+                let reply_target = Self::resolve_reply_target(&reply_to, &thread_view.id_map);
                 
                 if let Some(parent_node) = post_map_clone.get(&reply_target) {
                     // Parent exists, add to reply map
@@ -149,7 +152,7 @@ impl ThreadView {
                     } else {
                         // No match found even by timestamp, create a placeholder
                         let placeholder_post = Self::create_placeholder_post(&reply_target);
-                        let placeholder_node = ThreadNode::new(Arc::new(placeholder_post), 0);
+                        let placeholder_node = ThreadNode::new(Rc::new(RefCell::new(placeholder_post)), 0);
                         node.depth = 1; // Reply to placeholder at depth 0
                         
                         // Add placeholder to placeholder_map and this node as its reply
@@ -212,7 +215,7 @@ impl ThreadView {
 
         // Search through all posts for one with this timestamp as the ID
         for (full_id, node) in post_map {
-            if node.post.id() == timestamp {
+            if node.post.borrow().id() == timestamp {
                 return Some(full_id.clone());
             }
         }
@@ -253,7 +256,7 @@ impl ThreadView {
 
     /// Recursively attach replies to a specific node.
     fn attach_replies_to_node(node: &mut ThreadNode, reply_map: &HashMap<String, Vec<ThreadNode>>) {
-        let node_id = node.post.full_id();
+        let node_id = node.post.borrow().full_id();
         if let Some(replies) = reply_map.get(&node_id) {
             for mut reply in replies.clone() {
                 Self::attach_replies_to_node(&mut reply, reply_map);
@@ -293,7 +296,7 @@ impl ThreadView {
         self.roots.iter().map(|r| r.count_posts()).sum()
     }
 
-    pub fn flatten(&self) -> Vec<&Arc<Post>> {
+    pub fn flatten(&self) -> Vec<&Rc<RefCell<Post>>> {
         let mut posts = Vec::new();
         for root in &self.roots {
             posts.extend(root.flatten());
@@ -308,7 +311,7 @@ impl ThreadView {
     pub fn update_poll_node(&self, post_node: &ThreadNode, poll: &mut Poll) {
         poll.clear_votes();
         for reply in &post_node.replies {
-            poll.add_vote_from_reply(&reply.post);
+            poll.add_vote_from_reply(&*reply.post.borrow());
         }
     }
 
@@ -322,19 +325,20 @@ impl ThreadView {
     ///
     /// # Arguments
     /// * `post` - The new post to add to the thread tree
-    pub fn add_post(&mut self, post: Arc<Post>) {
-        if let Some(reply_to) = post.reply_to() {
-            let reply_target = Self::resolve_reply_target(reply_to, &self.id_map);
+    pub fn add_post(&mut self, post: Rc<RefCell<Post>>) {
+        if let Some(reply_to) = post.borrow().reply_to().clone() {
+            let reply_target = Self::resolve_reply_target(&reply_to, &self.id_map);
             
             // Try to find the parent in existing threads
             if self.find_and_add_reply(&reply_target, post.clone()).is_some() {
-                self.id_map.insert(post.id().to_string(), post.full_id());
+                let post_borrow = post.borrow();
+                self.id_map.insert(post_borrow.id().to_string(), post_borrow.full_id());
                 
                 self.sort_threads();
             } else {
                 // Parent not found - create placeholder and add as new root thread
                 let placeholder_post = Self::create_placeholder_post(&reply_target);
-                let mut placeholder_node = ThreadNode::new(Arc::new(placeholder_post), 0);
+                let mut placeholder_node = ThreadNode::new(Rc::new(RefCell::new(placeholder_post)), 0);
                 
                 let reply_node = ThreadNode::new(post.clone(), 1);
                 placeholder_node.add_reply(reply_node);
@@ -343,7 +347,8 @@ impl ThreadView {
                 
                 self.roots.push(placeholder_node);
                 
-                self.id_map.insert(post.id().to_string(), post.full_id());
+                let post_borrow = post.borrow();
+                self.id_map.insert(post_borrow.id().to_string(), post_borrow.full_id());
                 
                 // Resort threads
                 self.sort_threads();
@@ -353,7 +358,8 @@ impl ThreadView {
             let new_root = ThreadNode::new(post.clone(), 0);
             self.roots.push(new_root);
             
-            self.id_map.insert(post.id().to_string(), post.full_id());
+            let post_borrow = post.borrow();
+            self.id_map.insert(post_borrow.id().to_string(), post_borrow.full_id());
             
             // Resort threads
             self.sort_threads();
@@ -362,7 +368,7 @@ impl ThreadView {
 
     /// Recursively search for a target post ID and add a reply to it.
     /// Returns Some(depth) if the reply was successfully added, None if target not found.
-    fn find_and_add_reply(&mut self, target_id: &str, reply_post: Arc<Post>) -> Option<usize> {
+    fn find_and_add_reply(&mut self, target_id: &str, reply_post: Rc<RefCell<Post>>) -> Option<usize> {
         for root in &mut self.roots {
             if let Some(depth) = Self::find_and_add_reply_to_node(root, target_id, reply_post.clone()) {
                 return Some(depth);
@@ -373,9 +379,9 @@ impl ThreadView {
 
     /// Recursively search within a specific node and its descendants for the target ID.
     /// Returns Some(depth) if the reply was successfully added, None if target not found.
-    fn find_and_add_reply_to_node(node: &mut ThreadNode, target_id: &str, reply_post: Arc<Post>) -> Option<usize> {
+    fn find_and_add_reply_to_node(node: &mut ThreadNode, target_id: &str, reply_post: Rc<RefCell<Post>>) -> Option<usize> {
         // Check if this node is the target
-        if node.post.full_id() == target_id {
+        if node.post.borrow().full_id() == target_id {
             let reply_depth = node.depth + 1;
             let reply_node = ThreadNode::new(reply_post, reply_depth);
             node.add_reply(reply_node);
@@ -450,17 +456,18 @@ impl ThreadView {
     fn display_node(f: &mut std::fmt::Formatter<'_>, node: &ThreadNode, prefix: &str) -> std::fmt::Result {
         // Display the post with indentation
         let indent = "  ".repeat(node.depth);
-        writeln!(f, "{}{}Post ID: {}", prefix, indent, node.post.id())?;
+        let post = node.post.borrow();
+        writeln!(f, "{}{}Post ID: {}", prefix, indent, post.id())?;
         
-        if let Some(time) = node.post.time() {
+        if let Some(time) = post.time() {
             writeln!(f, "{prefix}{indent}Time: {time}")?;
         }
         
-        if let Some(author) = node.post.author() {
+        if let Some(author) = post.author() {
             writeln!(f, "{prefix}{indent}Author: {author}")?;
         }
         
-        writeln!(f, "{}{}Content: {}", prefix, indent, node.post.content())?;
+        writeln!(f, "{}{}Content: {}", prefix, indent, post.content())?;
         
         // Display replies
         for reply in &node.replies {
@@ -494,17 +501,17 @@ mod tests {
         
         // The root should be a placeholder post
         let root = &thread_view.roots[0];
-        assert_eq!(root.post.id(), "missing_post");
-        assert_eq!(root.post.content(), "[Post not available]");
-        assert_eq!(root.post.author().as_deref(), Some("unknown"));
+        assert_eq!(root.post.borrow().id(), "missing_post");
+        assert_eq!(root.post.borrow().content(), "[Post not available]");
+        assert_eq!(root.post.borrow().author().as_deref(), Some("unknown"));
         
         // The placeholder should have one reply
         assert_eq!(root.replies.len(), 1);
         
         // The reply should be our original post
         let reply_node = &root.replies[0];
-        assert_eq!(reply_node.post.id(), "reply1");
-        assert_eq!(reply_node.post.content(), "This is a reply");
+        assert_eq!(reply_node.post.borrow().id(), "reply1");
+        assert_eq!(reply_node.post.borrow().content(), "This is a reply");
         assert_eq!(reply_node.depth, 1);
     }
 
@@ -528,7 +535,7 @@ mod tests {
         
         // The root should be a placeholder post with two replies
         let root = &thread_view.roots[0];
-        assert_eq!(root.post.id(), "missing_post");
+        assert_eq!(root.post.borrow().id(), "missing_post");
         assert_eq!(root.replies.len(), 2);
         
         // Both replies should be at depth 1
@@ -558,16 +565,16 @@ mod tests {
         
         // The root should be the original post
         let root = &thread_view.roots[0];
-        assert_eq!(root.post.id(), "2025-08-15T10:30:00+00:00");
-        assert_eq!(root.post.content(), "Original post");
+        assert_eq!(root.post.borrow().id(), "2025-08-15T10:30:00+00:00");
+        assert_eq!(root.post.borrow().content(), "Original post");
         
         // The original post should have one reply
         assert_eq!(root.replies.len(), 1);
         
         // The reply should be our reply post
         let reply_node = &root.replies[0];
-        assert_eq!(reply_node.post.id(), "reply1");
-        assert_eq!(reply_node.post.content(), "This is a reply");
+        assert_eq!(reply_node.post.borrow().id(), "reply1");
+        assert_eq!(reply_node.post.borrow().content(), "This is a reply");
         assert_eq!(reply_node.depth, 1);
     }
 
@@ -589,17 +596,17 @@ mod tests {
         
         // The root should be a placeholder post
         let root = &thread_view.roots[0];
-        assert_eq!(root.post.id(), "2025-12-25T00:00:00+00:00");
-        assert_eq!(root.post.content(), "[Post not available]");
-        assert_eq!(root.post.author().as_deref(), Some("unknown"));
+        assert_eq!(root.post.borrow().id(), "2025-12-25T00:00:00+00:00");
+        assert_eq!(root.post.borrow().content(), "[Post not available]");
+        assert_eq!(root.post.borrow().author().as_deref(), Some("unknown"));
         
         // The placeholder should have one reply
         assert_eq!(root.replies.len(), 1);
         
         // The reply should be our original post
         let reply_node = &root.replies[0];
-        assert_eq!(reply_node.post.id(), "reply1");
-        assert_eq!(reply_node.post.content(), "This is a reply");
+        assert_eq!(reply_node.post.borrow().id(), "reply1");
+        assert_eq!(reply_node.post.borrow().content(), "This is a reply");
         assert_eq!(reply_node.depth, 1);
     }
 }

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -430,6 +430,34 @@ impl FeedView for ThreadView {
         // Re-sort threads and update flattened view
         self.sort_threads();
     }
+
+    /// Apply a filter closure to the posts in this view
+    /// This keeps only branches of the thread tree where at least one post matches the filter.
+    fn apply_filter(&mut self, filter_fn: Box<dyn Fn(&Post) -> bool>) {
+        fn filter_node(node: &ThreadNode, filter_fn: &dyn Fn(&Post) -> bool) -> Option<ThreadNode> {
+            let mut filtered_replies = Vec::new();
+            for reply in &node.replies {
+                if let Some(filtered_reply) = filter_node(reply, filter_fn) {
+                    filtered_replies.push(filtered_reply);
+                }
+            }
+            let matches = filter_fn(&node.post.borrow());
+            if matches || !filtered_replies.is_empty() {
+                let mut new_node = node.clone();
+                new_node.replies = filtered_replies;
+                Some(new_node)
+            } else {
+                None
+            }
+        }
+
+        self.roots = self.roots
+            .iter()
+            .filter_map(|root| filter_node(root, &*filter_fn))
+            .collect();
+        // After filtering, update latest activity times and sort threads
+        self.sort_threads();
+    }
 }
 
 impl Default for ThreadView {

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -3,15 +3,17 @@
 //! This module provides functionality to organize posts into threaded conversations
 //! based on reply relationships, creating hierarchical tree structures for display.
 
-use crate::{feed::Feed, poll::Poll, post::Post};
+use crate::feed;
+use crate::{feed::Feed, feed_view::FeedView, poll::Poll, post::Post, profile::Profile};
 use chrono::{DateTime, FixedOffset};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Represents a node in a threaded conversation tree.
 #[derive(Clone)]
 pub struct ThreadNode {
     /// The post at this node
-    pub post: Post,
+    pub post: Arc<Post>,
     /// Direct replies to this post
     pub replies: Vec<ThreadNode>,
     /// Depth level in the conversation (0 = root)
@@ -21,9 +23,7 @@ pub struct ThreadNode {
 }
 
 /// Represents a collection of threaded conversations.
-pub struct ThreadView<'a> {
-    /// Reference to the base feed
-    pub feed: &'a Feed,
+pub struct ThreadView {
     /// Root posts (posts that are not replies to anything)
     pub roots: Vec<ThreadNode>,
     /// Map of post IDs to their full identifiers for quick lookup
@@ -33,7 +33,7 @@ pub struct ThreadView<'a> {
 }
 
 impl ThreadNode {
-    pub fn new(post: Post, depth: usize) -> Self {
+    pub fn new(post: Arc<Post>, depth: usize) -> Self {
         let latest_activity_time = post.time();
         Self {
             post,
@@ -96,7 +96,7 @@ impl ThreadNode {
         1 + self.replies.iter().map(|r| r.count_posts()).sum::<usize>()
     }
 
-    pub fn flatten(&self) -> Vec<&Post> {
+    pub fn flatten(&self) -> Vec<&Arc<Post>> {
         let mut posts = vec![&self.post];
         for reply in &self.replies {
             posts.extend(reply.flatten());
@@ -105,30 +105,25 @@ impl ThreadNode {
     }
 }
 
-impl<'a> ThreadView<'a> {
-    pub fn new(feed: &'a Feed) -> Self {
-        Self {
-            feed,
+impl ThreadView {
+    /// Create a threaded view from a Feed.
+    pub fn from_feed(feed: &Feed) -> Self {
+        let mut thread_view = Self {
             roots: Vec::new(),
             id_map: HashMap::new(),
             placeholder_map: HashMap::new(),
-        }
-    }
-
-    /// Create a threaded view from a Feed.
-    pub fn from_feed(feed: &'a Feed) -> Self {
-        let mut thread_view = Self::new(feed);
+        };
         let mut post_map: HashMap<String, ThreadNode> = HashMap::new();
         let mut reply_map: HashMap<String, Vec<ThreadNode>> = HashMap::new();
 
         // Build ID mapping for quick lookups
-        for post in &feed.posts {
+        for post in feed.posts.iter() {
             let full_id: String = post.full_id();
             thread_view.id_map.insert(post.id().to_string(), full_id);
         }
 
         // First pass: create nodes for all posts
-        for post in &feed.posts {
+        for post in feed.posts.iter() {
             let node = ThreadNode::new(post.clone(), 0);
             let full_id = post.full_id();
             post_map.insert(full_id, node);
@@ -154,7 +149,7 @@ impl<'a> ThreadView<'a> {
                     } else {
                         // No match found even by timestamp, create a placeholder
                         let placeholder_post = Self::create_placeholder_post(&reply_target);
-                        let placeholder_node = ThreadNode::new(placeholder_post.clone(), 0);
+                        let placeholder_node = ThreadNode::new(Arc::new(placeholder_post), 0);
                         node.depth = 1; // Reply to placeholder at depth 0
                         
                         // Add placeholder to placeholder_map and this node as its reply
@@ -298,7 +293,7 @@ impl<'a> ThreadView<'a> {
         self.roots.iter().map(|r| r.count_posts()).sum()
     }
 
-    pub fn flatten(&self) -> Vec<&Post> {
+    pub fn flatten(&self) -> Vec<&Arc<Post>> {
         let mut posts = Vec::new();
         for root in &self.roots {
             posts.extend(root.flatten());
@@ -327,7 +322,7 @@ impl<'a> ThreadView<'a> {
     ///
     /// # Arguments
     /// * `post` - The new post to add to the thread tree
-    pub fn add_post(&mut self, post: Post) {
+    pub fn add_post(&mut self, post: Arc<Post>) {
         if let Some(reply_to) = post.reply_to() {
             let reply_target = Self::resolve_reply_target(reply_to, &self.id_map);
             
@@ -339,7 +334,7 @@ impl<'a> ThreadView<'a> {
             } else {
                 // Parent not found - create placeholder and add as new root thread
                 let placeholder_post = Self::create_placeholder_post(&reply_target);
-                let mut placeholder_node = ThreadNode::new(placeholder_post, 0);
+                let mut placeholder_node = ThreadNode::new(Arc::new(placeholder_post), 0);
                 
                 let reply_node = ThreadNode::new(post.clone(), 1);
                 placeholder_node.add_reply(reply_node);
@@ -367,7 +362,7 @@ impl<'a> ThreadView<'a> {
 
     /// Recursively search for a target post ID and add a reply to it.
     /// Returns Some(depth) if the reply was successfully added, None if target not found.
-    fn find_and_add_reply(&mut self, target_id: &str, reply_post: Post) -> Option<usize> {
+    fn find_and_add_reply(&mut self, target_id: &str, reply_post: Arc<Post>) -> Option<usize> {
         for root in &mut self.roots {
             if let Some(depth) = Self::find_and_add_reply_to_node(root, target_id, reply_post.clone()) {
                 return Some(depth);
@@ -378,7 +373,7 @@ impl<'a> ThreadView<'a> {
 
     /// Recursively search within a specific node and its descendants for the target ID.
     /// Returns Some(depth) if the reply was successfully added, None if target not found.
-    fn find_and_add_reply_to_node(node: &mut ThreadNode, target_id: &str, reply_post: Post) -> Option<usize> {
+    fn find_and_add_reply_to_node(node: &mut ThreadNode, target_id: &str, reply_post: Arc<Post>) -> Option<usize> {
         // Check if this node is the target
         if node.post.full_id() == target_id {
             let reply_depth = node.depth + 1;
@@ -404,19 +399,40 @@ impl<'a> ThreadView<'a> {
     }
 }
 
-impl<'a> From<&'a Feed> for ThreadView<'a> {
-    fn from(feed: &'a Feed) -> Self {
+impl From<&Feed> for ThreadView {
+    fn from(feed: &Feed) -> Self {
         ThreadView::from_feed(feed)
     }
 }
 
-impl<'a> Default for ThreadView<'a> {
-    fn default() -> Self {
-        panic!("ThreadView::default() is not supported, use ThreadView::new(feed)");
+impl FeedView for ThreadView {
+    fn len(&self) -> usize {
+        self.total_posts()
+    }
+
+    fn update_content(&mut self, feed: &Feed) {
+        // TODO: More efficient incremental update could be implemented
+        let new_view = ThreadView::from_feed(feed);
+        *self = new_view;
+    }
+
+    fn view_name(&self) -> &str {
+        "Thread View"
+    }
+
+    fn refresh(&mut self) {
+        // Re-sort threads and update flattened view
+        self.sort_threads();
     }
 }
 
-impl<'a> std::fmt::Display for ThreadView<'a> {
+impl Default for ThreadView {
+    fn default() -> Self {
+        panic!("ThreadView::default() is not supported, use ThreadView::new()");
+    }
+}
+
+impl std::fmt::Display for ThreadView {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Thread View with {} conversations:", self.thread_count())?;
         
@@ -429,7 +445,7 @@ impl<'a> std::fmt::Display for ThreadView<'a> {
     }
 }
 
-impl<'a> ThreadView<'a> {
+impl ThreadView {
     /// Helper method to display a thread node with proper indentation.
     fn display_node(f: &mut std::fmt::Formatter<'_>, node: &ThreadNode, prefix: &str) -> std::fmt::Result {
         // Display the post with indentation
@@ -470,7 +486,7 @@ mod tests {
         let posts = vec![reply_post.clone()];
         
         // Create thread view
-        let feed = crate::feed::Feed { posts: posts.clone(), profiles: vec![], profile_map: std::collections::HashMap::new() };
+        let feed = crate::feed::Feed::from_posts(posts.clone());
         let thread_view = ThreadView::from_feed(&feed);
         
         // Should have one root thread (the placeholder)
@@ -504,7 +520,7 @@ mod tests {
         let posts = vec![reply1, reply2];
         
         // Create thread view
-        let feed = crate::feed::Feed { posts: posts.clone(), profiles: vec![], profile_map: std::collections::HashMap::new() };
+        let feed = crate::feed::Feed::from_posts(posts.clone());
         let thread_view = ThreadView::from_feed(&feed);
         
         // Should have one root thread (the placeholder)
@@ -534,7 +550,7 @@ mod tests {
         let posts = vec![original_post.clone(), reply_post.clone()];
         
         // Create thread view
-        let feed = crate::feed::Feed { posts: posts.clone(), profiles: vec![], profile_map: std::collections::HashMap::new() };
+        let feed = crate::feed::Feed::from_posts(posts.clone());
         let thread_view = ThreadView::from_feed(&feed);
         
         // Should have one root thread (the original post)
@@ -565,7 +581,7 @@ mod tests {
         let posts = vec![reply_post.clone()];
         
         // Create thread view
-        let feed = crate::feed::Feed { posts: posts.clone(), profiles: vec![], profile_map: std::collections::HashMap::new() };
+        let feed = crate::feed::Feed::from_posts(posts.clone());
         let thread_view = ThreadView::from_feed(&feed);
         
         // Should have one root thread (the placeholder)

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -49,7 +49,8 @@ impl Tokenizer {
             }
         }
         
-        tokens
+        // Merge consecutive plaintext tokens for cleaner output
+        self.merge_consecutive_plaintext(tokens)
     }
 
     fn next_token(&mut self) -> Option<Token> {
@@ -358,6 +359,54 @@ impl Tokenizer {
     fn advance(&mut self, count: usize) {
         self.position = std::cmp::min(self.position + count, self.input.len());
     }
+
+    /// Merges consecutive PlainText tokens that are not separated by newlines
+    /// This helps clean up fragmented plaintext tokens that can occur when
+    /// parsing of other token types fails
+    fn merge_consecutive_plaintext(&self, tokens: Vec<Token>) -> Vec<Token> {
+        if tokens.is_empty() {
+            return tokens;
+        }
+
+        let mut merged = Vec::new();
+        let mut current_plaintext = String::new();
+        
+        for token in tokens {
+            match token {
+                Token::PlainText(text) => {
+                    // Check if the text contains newlines
+                    if text.contains('\n') {
+                        // If we have accumulated plaintext, add it first
+                        if !current_plaintext.is_empty() {
+                            merged.push(Token::PlainText(current_plaintext.clone()));
+                            current_plaintext.clear();
+                        }
+                        merged.push(Token::PlainText(text));
+                    } else {
+                        // Accumulate consecutive plaintext without newlines
+                        current_plaintext.push_str(&text);
+                    }
+                }
+                other_token => {
+                    // We hit a non-plaintext token
+                    // First, add any accumulated plaintext
+                    if !current_plaintext.is_empty() {
+                        merged.push(Token::PlainText(current_plaintext.clone()));
+                        current_plaintext.clear();
+                    }
+                    // Then add the other token
+                    merged.push(other_token);
+                }
+            }
+        }
+        
+        // Add the remaining accumulated plaintext if any
+        if !current_plaintext.is_empty() {
+            merged.push(Token::PlainText(current_plaintext));
+        }
+        
+        merged
+    }
 }
 
 #[cfg(test)]
@@ -414,13 +463,11 @@ mod tests {
             let mut tokenizer = Tokenizer::new(input.clone());
             let tokens = tokenizer.tokenize();
             
-            // Should be parsed as separate plain text tokens
+            // Should be parsed as merged plain text tokens (consecutive ones are now merged)
             assert_eq!(tokens, vec![
-                Token::PlainText("This ".to_string()),
-                Token::PlainText(delimiter.to_string()),
+                Token::PlainText(format!("This {}", delimiter)),
                 Token::PlainText("spans\nmultiple".to_string()),
-                Token::PlainText(delimiter.to_string()),
-                Token::PlainText(" lines".to_string()),
+                Token::PlainText(format!("{} lines", delimiter)),
             ], "Failed for delimiter: {}", delimiter);
         }
     }
@@ -441,24 +488,21 @@ mod tests {
     #[test]
     fn test_formatting_empty_content_rejected() {
         let test_cases = vec![
-            ("**", '*'),
-            ("//", '/'),
-            ("__", '_'),
-            ("++", '+'),
-            ("~~", '~'),
+            "**",
+            "//",
+            "__",
+            "++",
+            "~~",
         ];
 
-        for (input, delimiter) in test_cases {
+        for input in test_cases {
             let test_input = format!("This is {} empty", input);
             let mut tokenizer = Tokenizer::new(test_input.clone());
             let tokens = tokenizer.tokenize();
             
-            // Should be parsed as separate plain text tokens
+            // Should be parsed as merged plain text (consecutive plaintext tokens are now merged)
             assert_eq!(tokens, vec![
-                Token::PlainText("This is ".to_string()),
-                Token::PlainText(delimiter.to_string()),
-                Token::PlainText(delimiter.to_string()),
-                Token::PlainText(" empty".to_string()),
+                Token::PlainText(format!("This is {} empty", input)),
             ], "Failed for input: {}", input);
         }
     }
@@ -467,24 +511,21 @@ mod tests {
     #[test]
     fn test_formatting_unclosed_delimiters() {
         let test_cases = vec![
-            ("*unclosed bold", '*'),
-            ("/unclosed italic", '/'),
-            ("_unclosed underline", '_'),
-            ("+unclosed strikethrough", '+'),
-            ("~unclosed code", '~'),
+            "*unclosed bold",
+            "/unclosed italic",
+            "_unclosed underline",
+            "+unclosed strikethrough",
+            "~unclosed code",
         ];
 
-        for (input, delimiter) in test_cases {
+        for input in test_cases {
             let test_input = format!("This is {}", input);
             let mut tokenizer = Tokenizer::new(test_input.clone());
             let tokens = tokenizer.tokenize();
             
-            // Should be parsed as separate plain text tokens
-            let expected_text = input.split_at(1);
+            // Should be parsed as merged plain text (consecutive plaintext tokens are now merged)
             assert_eq!(tokens, vec![
-                Token::PlainText("This is ".to_string()),
-                Token::PlainText(delimiter.to_string()),
-                Token::PlainText(expected_text.1.to_string()),
+                Token::PlainText(format!("This is {}", input)),
             ], "Failed for input: {}", input);
         }
     }
@@ -590,11 +631,9 @@ mod tests {
         let mut tokenizer = Tokenizer::new("Connect via ftp://files.example.com or matrix://matrix.org".to_string());
         let tokens = tokenizer.tokenize();
         assert_eq!(tokens, vec![
-            Token::PlainText("Connect via ftp:".to_string()),
-            Token::PlainText("/".to_string()),
+            Token::PlainText("Connect via ftp:/".to_string()),
             Token::Italic("files.example.com or matrix:".to_string()),
-            Token::PlainText("/".to_string()),
-            Token::PlainText("matrix.org".to_string()),
+            Token::PlainText("/matrix.org".to_string()),
         ]);
     }
 
@@ -683,5 +722,103 @@ mod tests {
                 username: "alice_123@domain".to_string(),
             },
         ]);
+    }
+
+    #[test]
+    fn test_merge_consecutive_plaintext_basic() {
+        // Test the merge function directly by creating fragmented tokens
+        let tokenizer = Tokenizer::new("".to_string());
+        let fragmented_tokens = vec![
+            Token::PlainText("Hello ".to_string()),
+            Token::PlainText("world".to_string()),
+            Token::PlainText("!".to_string()),
+        ];
+        let merged = tokenizer.merge_consecutive_plaintext(fragmented_tokens);
+        assert_eq!(merged, vec![Token::PlainText("Hello world!".to_string())]);
+    }
+
+    #[test]
+    fn test_merge_consecutive_plaintext_with_other_tokens() {
+        let tokenizer = Tokenizer::new("".to_string());
+        let mixed_tokens = vec![
+            Token::PlainText("Start ".to_string()),
+            Token::PlainText("text ".to_string()),
+            Token::Bold("bold".to_string()),
+            Token::PlainText(" end".to_string()),
+            Token::PlainText(" more".to_string()),
+        ];
+        let merged = tokenizer.merge_consecutive_plaintext(mixed_tokens);
+        assert_eq!(merged, vec![
+            Token::PlainText("Start text ".to_string()),
+            Token::Bold("bold".to_string()),
+            Token::PlainText(" end more".to_string()),
+        ]);
+    }
+
+    #[test]
+    fn test_merge_consecutive_plaintext_preserves_newlines() {
+        let tokenizer = Tokenizer::new("".to_string());
+        let tokens_with_newlines = vec![
+            Token::PlainText("Line 1".to_string()),
+            Token::PlainText("\n".to_string()),
+            Token::PlainText("Line 2".to_string()),
+        ];
+        let merged = tokenizer.merge_consecutive_plaintext(tokens_with_newlines);
+        // Newlines should prevent merging
+        assert_eq!(merged, vec![
+            Token::PlainText("Line 1".to_string()),
+            Token::PlainText("\n".to_string()),
+            Token::PlainText("Line 2".to_string()),
+        ]);
+    }
+
+    #[test]
+    fn test_merge_consecutive_plaintext_mixed_with_newlines() {
+        let tokenizer = Tokenizer::new("".to_string());
+        let mixed_tokens = vec![
+            Token::PlainText("Before ".to_string()),
+            Token::PlainText("merge".to_string()),
+            Token::PlainText("\nWith newline".to_string()),
+            Token::PlainText("After ".to_string()),
+            Token::PlainText("merge".to_string()),
+        ];
+        let merged = tokenizer.merge_consecutive_plaintext(mixed_tokens);
+        assert_eq!(merged, vec![
+            Token::PlainText("Before merge".to_string()),
+            Token::PlainText("\nWith newline".to_string()),
+            Token::PlainText("After merge".to_string()),
+        ]);
+    }
+
+    #[test]
+    fn test_merge_consecutive_plaintext_empty_tokens() {
+        let tokenizer = Tokenizer::new("".to_string());
+        let tokens_with_empty = vec![
+            Token::PlainText("Hello".to_string()),
+            Token::PlainText("".to_string()),
+            Token::PlainText(" world".to_string()),
+        ];
+        let merged = tokenizer.merge_consecutive_plaintext(tokens_with_empty);
+        assert_eq!(merged, vec![Token::PlainText("Hello world".to_string())]);
+    }
+
+    #[test] 
+    fn test_tokenizer_produces_merged_output() {
+        // This test verifies that the tokenizer integration actually produces merged output
+        // for cases where fragmentation would previously occur
+        let mut tokenizer = Tokenizer::new("ftp://example.com".to_string());
+        let tokens = tokenizer.tokenize();
+        // Before the merge, this would create ["ftp:", "/", "/", "example.com"]
+        // After the merge, it should be a single plaintext token
+        assert_eq!(tokens, vec![Token::PlainText("ftp://example.com".to_string())]);
+    }
+
+    #[test]
+    fn test_tokenizer_merge_with_failed_formatting() {
+        // Test case where formatting fails and creates fragmented plaintext
+        let mut tokenizer = Tokenizer::new("unclosed *bold text".to_string());
+        let tokens = tokenizer.tokenize();
+        // Should merge the fragmented plaintext from the failed bold parsing
+        assert_eq!(tokens, vec![Token::PlainText("unclosed *bold text".to_string())]);
     }
 }


### PR DESCRIPTION
This is a big one, with multiple breaking changes.
The target is the org-social 1.3 release now.

Feed is now a collection of posts, it is supposed to be viewed using "Feed Views". It's optimized for single threading, now the post instances are shared between views.

View filtering is now possible in feed views, with some premade filters and ability to use custom ones. Filtering is non-destructive, applies to specific/all views but not the underlying feed. Only one filter at a time for now.

Groups are now parsed from posts and profiles, views can be filtered by them. More group support will come in the next release, with relay support.

Profiles can be saved back into files, some minor tokenization improvements, extra traits for posts & profiles.

See CHANGELOG.md for details